### PR TITLE
feat: hide "case monitoring" data when switching to another use case

### DIFF
--- a/src/case-monitoring.ts
+++ b/src/case-monitoring.ts
@@ -10,7 +10,7 @@ const registeredBpmnElements = new Map<Element, BpmnSemantic>();
 
 let alreadyExecutedElements = new Set<string>();
 
-export function showMonitoringData(bpmnVisualization: BpmnVisualization) {
+export function showCaseMonitoringData(bpmnVisualization: BpmnVisualization) {
   const alreadyExecutedShapes = getAlreadyExecutedShapes();
   const alreadyVisitedEdges = getConnectingEdgeIds(new Set<string>([...alreadyExecutedShapes, ...(getRunningActivities()), ...getPendingElements()]), bpmnVisualization);
   alreadyExecutedElements = new Set<string>([...alreadyExecutedShapes, ...alreadyVisitedEdges]);
@@ -23,7 +23,7 @@ export function showMonitoringData(bpmnVisualization: BpmnVisualization) {
   // registerInteractions(bpmnVisualization);
 }
 
-export function hideMonitoringData(bpmnVisualization: BpmnVisualization) {
+export function hideCaseMonitoringData(bpmnVisualization: BpmnVisualization) {
   restoreVisibilityOfAlreadyExecutedElements(bpmnVisualization);
   resetRunningElements(bpmnVisualization);
 }

--- a/src/radio-buttons.ts
+++ b/src/radio-buttons.ts
@@ -1,5 +1,5 @@
 import {type BpmnVisualization} from 'bpmn-visualization';
-import {hideMonitoringData, showMonitoringData} from './case-monitoring.js';
+import {hideCaseMonitoringData, showCaseMonitoringData} from './case-monitoring.js';
 
 /**
  * @param {BpmnVisualization} bpmnVisualization
@@ -10,9 +10,9 @@ export function configureRadioButtons(bpmnVisualization: BpmnVisualization) {
 
   // eslint-disable-next-line no-new
   new RadioButton('radio-case-monitoring', () => {
-    showMonitoringData(bpmnVisualization);
+    showCaseMonitoringData(bpmnVisualization);
   }, () => {
-    hideMonitoringData(bpmnVisualization);
+    hideCaseMonitoringData(bpmnVisualization);
   });
   // eslint-disable-next-line no-new
   new RadioButton('radio-reset-all', () => {


### PR DESCRIPTION
Also blur edge incoming to the pending gateway because they relate to a path that is already executed.


### Screenshots

**Note**: from Firefox on Ubuntu 20.04


![01_executed_path_before](https://user-images.githubusercontent.com/27200110/224386442-d587df29-3ae5-4520-a325-fb0b07f2d913.png)
_Executed path before this PR_



https://user-images.githubusercontent.com/27200110/224386621-a3c71347-b9b6-40e4-b1d3-dcb889f1ab7f.mp4

