### PR TITLE
refactor: simplify some code and build scripts

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -13,10 +13,8 @@ runs:
       uses: actions/setup-node@v3
       with:
         node-version-file: '.nvmrc'
-        cache: "npm"
     - name: Install dependencies
-      shell: bash
-      run: npm ci
+      uses: bahmutov/npm-install@v1
     - name: Build
       shell: bash
       run: npm run ${{ inputs.npm-script }}

--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -4,7 +4,7 @@ inputs:
   npm-script:
     description: 'The name of the npm script to run.'
     required: false
-    default: 'build-demo'
+    default: 'build'
 
 runs:
   using: 'composite'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,6 @@ jobs:
       - name: Build
         uses: ./.github/actions/build
         with:
-          npm-script: 'ts'
+          npm-script: 'tsc'
       - name: Check
         run: npm test

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -28,8 +28,6 @@ jobs:
       - name: Build
         uses: ./.github/actions/build
         if: github.event.action != 'closed'
-        with:
-          npm-script: 'build-for-surge'
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         if: github.event.action != 'closed'

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ The demo is accessible at http://localhost:5173/
 
 The code should be linted with [xo](https://github.com/xojs/xo). To have support in your favorite IDE, see the [how-to used in IDE](https://github.com/xojs/xo#editor-plugins) documentation. 
 
+To lint the code, run `npm run lint`.
+
 
 ## 📃 License
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
-    "build-demo": "vite build --base ./",
-    "build-for-surge": "vite build",
+    "build": "vite build --base ./",
     "lint": "xo --fix",
     "preview": "vite preview --base ./",
     "test": "xo",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "xo --fix",
     "preview": "vite preview --base ./",
     "test": "xo",
-    "ts": "tsc"
+    "tsc": "tsc"
   },
   "dependencies": {
     "bpmn-visualization": "~0.32.0",

--- a/src/bpmn-elements.ts
+++ b/src/bpmn-elements.ts
@@ -1,47 +1,47 @@
-const activitiesMap = new Map<string, string>();
-activitiesMap.set('Activity_0ec8azh', 'SRM subprocess');
-activitiesMap.set('Activity_1t65hvk', 'Create Purchase Order Item');
-activitiesMap.set('Activity_06cvihl', 'Record Service Entry Sheet');
-activitiesMap.set('Activity_00vbm9s', 'Record Goods Receipts');
-activitiesMap.set('Activity_1u4jwkv', 'Record Invoice Receipt');
-activitiesMap.set('Activity_083jf01', 'Remove Payment Block');
-activitiesMap.set('Activity_0yabbur', 'Clear Invoice');
+const activities = new Map<string, string>();
+activities.set('Activity_0ec8azh', 'SRM subprocess');
+activities.set('Activity_1t65hvk', 'Create Purchase Order Item');
+activities.set('Activity_06cvihl', 'Record Service Entry Sheet');
+activities.set('Activity_00vbm9s', 'Record Goods Receipts');
+activities.set('Activity_1u4jwkv', 'Record Invoice Receipt');
+activities.set('Activity_083jf01', 'Remove Payment Block');
+activities.set('Activity_0yabbur', 'Clear Invoice');
 
-const gatewaysMap = new Map<string, string>();
-gatewaysMap.set('Gateway_0xh0plz', 'parallelGatewaySplit1');
-gatewaysMap.set('Gateway_0domayw', 'parallelGatewayJoin1');
-gatewaysMap.set('Gateway_0apcz1e', 'parallelGatewaySplit2');
-gatewaysMap.set('Gateway_01gpztl', 'parallelGatewayJoin2');
-gatewaysMap.set('Gateway_08gf298', 'exclusiveGatewaySplit1');
-gatewaysMap.set('Gateway_0jqn9hp', 'exclusiveGatewayJoin1');
-gatewaysMap.set('Gateway_0a68dfj', 'exclusiveGatewaySplit2');
-gatewaysMap.set('Gateway_1ezcj46', 'exclusiveGatewayJoin2');
+const gateways = new Map<string, string>();
+gateways.set('Gateway_0xh0plz', 'parallelGatewaySplit1');
+gateways.set('Gateway_0domayw', 'parallelGatewayJoin1');
+gateways.set('Gateway_0apcz1e', 'parallelGatewaySplit2');
+gateways.set('Gateway_01gpztl', 'parallelGatewayJoin2');
+gateways.set('Gateway_08gf298', 'exclusiveGatewaySplit1');
+gateways.set('Gateway_0jqn9hp', 'exclusiveGatewayJoin1');
+gateways.set('Gateway_0a68dfj', 'exclusiveGatewaySplit2');
+gateways.set('Gateway_1ezcj46', 'exclusiveGatewayJoin2');
 
-const eventsMap = new Map<string, string>();
-eventsMap.set('Event_1vogvxc', 'New POI Needed');
-eventsMap.set('Event_0e43ncy', 'Vendor Creates Invoice');
-eventsMap.set('Event_07598zy', 'endEvent');
+const events = new Map<string, string>();
+events.set('Event_1vogvxc', 'New POI Needed');
+events.set('Event_0e43ncy', 'Vendor Creates Invoice');
+events.set('Event_07598zy', 'endEvent');
 
 export function isActivity(elementId: string): boolean {
-  return activitiesMap.has(elementId);
+  return activities.has(elementId);
 }
 
 export function isGateway(elementId: string): boolean {
-  return gatewaysMap.has(elementId);
+  return gateways.has(elementId);
 }
 
 export function isEvent(elementId: string): boolean {
-  return eventsMap.has(elementId);
+  return events.has(elementId);
 }
 
 export function getElementIdByName(elementName: string): string | undefined {
-  for (const [key, value] of activitiesMap.entries()) {
+  for (const [key, value] of activities.entries()) {
     if (value === elementName) {
       return key;
     }
   }
 
-  for (const [key, value] of eventsMap.entries()) {
+  for (const [key, value] of events.entries()) {
     if (value === elementName) {
       return key;
     }

--- a/src/breadcrumb.ts
+++ b/src/breadcrumb.ts
@@ -1,16 +1,16 @@
 // Remove section of secondary diagram in Breadcrumb
 export function removeSectionInBreadcrumb(): void {
-  const breadcrumbElt = document.querySelectorAll('.breadcrumb').item(0);
-  if (breadcrumbElt) {
-    const secondaryDiagramElt = document.querySelector('#secondary-diagram');
-    if (secondaryDiagramElt) {
-      secondaryDiagramElt.remove();
-    }
-  }
+  const secondaryDiagramElt = document.querySelectorAll('.breadcrumb > #secondary-diagram').item(0);
+  secondaryDiagramElt?.remove();
 }
 
 // Add section of secondary diagram in Breadcrumb
 export function addSectionInBreadcrumb(): void {
+  const breadcrumbElt = document.querySelectorAll('.breadcrumb').item(0);
+  if (!breadcrumbElt) {
+    return;
+  }
+
   const aElt = document.createElement('a');
   aElt.setAttribute('href', '#');
   aElt.append(document.createTextNode('SRM subprocess'));
@@ -20,8 +20,5 @@ export function addSectionInBreadcrumb(): void {
   liElt.setAttribute('class', 'breadcrumb-item');
   liElt.append(aElt);
 
-  const breadcrumbElt = document.querySelectorAll('.breadcrumb').item(0);
-  if (breadcrumbElt) {
-    breadcrumbElt.append(liElt);
-  }
+  breadcrumbElt.append(liElt);
 }

--- a/src/diagram.ts
+++ b/src/diagram.ts
@@ -1,7 +1,9 @@
-import {BpmnVisualization, FitType} from 'bpmn-visualization';
+import {BpmnVisualization, FitType, type LoadOptions} from 'bpmn-visualization';
 // eslint-disable-next-line n/file-extension-in-import -- Vite syntax
 import subDiagram from './diagrams/SRM-subprocess.bpmn?raw';
 import {removeSectionInBreadcrumb, addSectionInBreadcrumb} from './breadcrumb.js';
+
+export const sharedLoadOptions: LoadOptions = {fit: {type: FitType.Center, margin: 20}};
 
 let secondaryBpmnDiagramIsAlreadyLoad = false;
 let currentView = 'main';
@@ -9,7 +11,7 @@ let currentView = 'main';
 // Secondary BPMN Container
 const secondaryBpmnVisualization = new BpmnVisualization({container: 'secondary-bpmn-container'});
 
-export function loadBpmnDiagram(tabIndex: string): void {
+export function displayBpmnDiagram(tabIndex: string): void {
   if (currentView === tabIndex) {
     return;
   }
@@ -25,7 +27,7 @@ export function loadBpmnDiagram(tabIndex: string): void {
 
       if (!secondaryBpmnDiagramIsAlreadyLoad) {
         // Load secondary diagram. Need to have the container displayed
-        secondaryBpmnVisualization.load(subDiagram, {fit: {type: FitType.Center, margin: 10}});
+        secondaryBpmnVisualization.load(subDiagram, sharedLoadOptions);
         secondaryBpmnDiagramIsAlreadyLoad = true;
       }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {BpmnVisualization, FitType} from 'bpmn-visualization';
+import {BpmnVisualization} from 'bpmn-visualization';
 // eslint-disable-next-line n/file-extension-in-import -- Vite syntax
 import collapsedDiagram from './diagrams/EC-purchase-orders-collapsed.bpmn?raw';
-import {loadBpmnDiagram} from './diagram.js';
+import {displayBpmnDiagram, sharedLoadOptions} from './diagram.js';
 import {configureRadioButtons} from './radio-buttons.js';
 
 // 'bpmn-visualization' API documentation: https://process-analytics.github.io/bpmn-visualization-js/api/index.html
@@ -26,20 +26,18 @@ const mainBpmnVisualization = new BpmnVisualization({
 });
 
 // Load BPMN diagram
-// Try the "Center" type to fit the whole container and center the diagram
-mainBpmnVisualization.load(collapsedDiagram, {fit: {type: FitType.Center, margin: 20}});
+mainBpmnVisualization.load(collapsedDiagram, sharedLoadOptions);
 
-// Interaction
+// Interaction: open the sub-process
 const subProcessId = 'Activity_0ec8azh';
 mainBpmnVisualization.bpmnElementsRegistry.getElementsByIds(subProcessId)[0].htmlElement.addEventListener('click', () => {
-  loadBpmnDiagram('secondary');
+  displayBpmnDiagram('secondary');
 });
+mainBpmnVisualization.bpmnElementsRegistry.addCssClasses(subProcessId, 'c-hand');
 
 // Return to main diagram
 document.querySelector('#breadcrumb-main-diagram')!.addEventListener('click', () => {
-  loadBpmnDiagram('main');
+  displayBpmnDiagram('main');
 });
-
-mainBpmnVisualization.bpmnElementsRegistry.addCssClasses(subProcessId, 'c-hand');
 
 configureRadioButtons(mainBpmnVisualization);

--- a/src/radio-buttons.ts
+++ b/src/radio-buttons.ts
@@ -2,6 +2,9 @@ import {type BpmnVisualization} from 'bpmn-visualization';
 import {hideMonitoringData, showMonitoringData} from './case-monitoring.js';
 import {hideHappyPath, showHappyPath} from './process-monitoring.js';
 
+/**
+ * @param {BpmnVisualization} bpmnVisualization
+ */
 export function configureRadioButtons(bpmnVisualization: BpmnVisualization) {
   // eslint-disable-next-line no-warning-comments -- cannot be managed now
   // TODO try to having calling constructor for side effects

--- a/src/radio-buttons.ts
+++ b/src/radio-buttons.ts
@@ -1,9 +1,6 @@
 import {type BpmnVisualization} from 'bpmn-visualization';
 import {hideMonitoringData, showMonitoringData} from './case-monitoring.js';
 
-/**
- * @param {BpmnVisualization} bpmnVisualization
- */
 export function configureRadioButtons(bpmnVisualization: BpmnVisualization) {
   // eslint-disable-next-line no-warning-comments -- cannot be managed now
   // TODO try to having calling constructor for side effects


### PR DESCRIPTION
- Do not put type information in the name of the variables (this is useless as we used types)
- Simplify CSS selector to get elements of the breadcrumb
- Share diagram load options for the all diagrams
- Build and workflows
  - Use a more convenient name for the npm script that does TS compilation
  - Keep a single build demo npm script for simplificty
  - Use the `bahmutov/npm-install` action to manage cache and dependencies install

### Notes

The "build and workflows" improvements will be then contributed back to https://github.com/process-analytics/bpmn-visualization-demo-template: https://github.com/process-analytics/bpmn-visualization-demo-template/pull/7