### PR TITLE
feat: add resource allocation interaction (1st step)

### DIFF
--- a/src/bpmn-elements.ts
+++ b/src/bpmn-elements.ts
@@ -1,93 +1,35 @@
-const mainActivities = new Map<string, string>();
-mainActivities.set('Activity_0ec8azh', 'SRM subprocess');
-mainActivities.set('Activity_1t65hvk', 'Create Purchase Order Item');
-mainActivities.set('Activity_06cvihl', 'Record Service Entry Sheet');
-mainActivities.set('Activity_00vbm9s', 'Record Goods Receipts');
-mainActivities.set('Activity_1u4jwkv', 'Record Invoice Receipt');
-mainActivities.set('Activity_083jf01', 'Remove Payment Block');
-mainActivities.set('Activity_0yabbur', 'Clear Invoice');
+const activities = new Map<string, string>();
+activities.set('Activity_0ec8azh', 'SRM subprocess');
+activities.set('Activity_1t65hvk', 'Create Purchase Order Item');
+activities.set('Activity_06cvihl', 'Record Service Entry Sheet');
+activities.set('Activity_00vbm9s', 'Record Goods Receipts');
+activities.set('Activity_1u4jwkv', 'Record Invoice Receipt');
+activities.set('Activity_083jf01', 'Remove Payment Block');
+activities.set('Activity_0yabbur', 'Clear Invoice');
 
-const mainGateways = new Map<string, string>();
-mainGateways.set('Gateway_0xh0plz', 'parallelGatewaySplit1');
-mainGateways.set('Gateway_0domayw', 'parallelGatewayJoin1');
-mainGateways.set('Gateway_0apcz1e', 'parallelGatewaySplit2');
-mainGateways.set('Gateway_01gpztl', 'parallelGatewayJoin2');
-mainGateways.set('Gateway_08gf298', 'exclusiveGatewaySplit1');
-mainGateways.set('Gateway_0jqn9hp', 'exclusiveGatewayJoin1');
-mainGateways.set('Gateway_0a68dfj', 'exclusiveGatewaySplit2');
-mainGateways.set('Gateway_1ezcj46', 'exclusiveGatewayJoin2');
+const gateways = new Map<string, string>();
+gateways.set('Gateway_0xh0plz', 'parallelGatewaySplit1');
+gateways.set('Gateway_0domayw', 'parallelGatewayJoin1');
+gateways.set('Gateway_0apcz1e', 'parallelGatewaySplit2');
+gateways.set('Gateway_01gpztl', 'parallelGatewayJoin2');
+gateways.set('Gateway_08gf298', 'exclusiveGatewaySplit1');
+gateways.set('Gateway_0jqn9hp', 'exclusiveGatewayJoin1');
+gateways.set('Gateway_0a68dfj', 'exclusiveGatewaySplit2');
+gateways.set('Gateway_1ezcj46', 'exclusiveGatewayJoin2');
 
-const mainEvents = new Map<string, string>();
-mainEvents.set('Event_1vogvxc', 'New POI Needed');
-mainEvents.set('Event_0e43ncy', 'Vendor Creates Invoice');
-mainEvents.set('Event_07598zy', 'endEvent');
+const events = new Map<string, string>();
+events.set('Event_1vogvxc', 'New POI Needed');
+events.set('Event_0e43ncy', 'Vendor Creates Invoice');
+events.set('Event_07598zy', 'endEvent');
 
-/*
-  BPMN elements of secondary process
-*/
-const secondaryActivities = new Map<string, string>();
-secondaryActivities.set('Activity_157vm5m', 'SRM: Created');
-secondaryActivities.set('Activity_1243ie0', 'SRM: Complete');
-secondaryActivities.set('Activity_1p3opxc', 'SRM: Awaiting Approval');
-secondaryActivities.set('Activity_015g8ru', 'SRM: Document Completed');
-secondaryActivities.set('Activity_0k8i7cb', 'SRM: Ordered');
-secondaryActivities.set('Activity_0yyl6g2', 'SRM: In Transfer to Execution Syst.');
-secondaryActivities.set('Activity_16tcn1j', 'SRM: Change was Transmitted');
-
-const secondaryGateways = new Map<string, string>();
-secondaryGateways.set('Gateway_0w0fs3j', 'parallelGatewaySplit1');
-secondaryGateways.set('Gateway_1cjjox7', 'parallelGatewayJoin1');
-
-const secondaryEvents = new Map<string, string>();
-secondaryEvents.set('Event_1dnxra5', 'New SRM entry');
-secondaryEvents.set('Event_0bp3ymm', 'endEvent');
-
-export function isActivity(elementId: string, processId: string): boolean {
-  if (processId === 'main') {
-    return mainActivities.has(elementId);
-  }
-
-  return secondaryActivities.has(elementId);
+export function isActivity(elementId: string): boolean {
+  return activities.has(elementId);
 }
 
-export function isGateway(elementId: string, processId: string): boolean {
-  if (processId === 'main') {
-    return mainGateways.has(elementId);
-  }
-
-  return secondaryGateways.has(elementId);
+export function isGateway(elementId: string): boolean {
+  return gateways.has(elementId);
 }
 
-export function isEvent(elementId: string, processId: string): boolean {
-  if (processId === 'main') {
-    return mainEvents.has(elementId);
-  }
-
-  return secondaryEvents.has(elementId);
+export function isEvent(elementId: string): boolean {
+  return events.has(elementId);
 }
-
-// Export function getElementIdByName(elementName: string, processId: string): string | undefined {
-//   let activities = new Map<string, string>();
-//   let events = new Map<string, string>();
-//   if (processId === 'main') {
-//     activities = mainActivities;
-//     events = mainEvents;
-//   } else {
-//     activities = secondaryActivities;
-//     events = secondaryEvents;
-//   }
-//
-//   for (const [key, value] of activities.entries()) {
-//     if (value === elementName) {
-//       return key;
-//     }
-//   }
-//
-//   for (const [key, value] of events.entries()) {
-//     if (value === elementName) {
-//       return key;
-//     }
-//   }
-//
-//   return undefined;
-// }

--- a/src/bpmn-elements.ts
+++ b/src/bpmn-elements.ts
@@ -1,51 +1,95 @@
-const activities = new Map<string, string>();
-activities.set('Activity_0ec8azh', 'SRM subprocess');
-activities.set('Activity_1t65hvk', 'Create Purchase Order Item');
-activities.set('Activity_06cvihl', 'Record Service Entry Sheet');
-activities.set('Activity_00vbm9s', 'Record Goods Receipts');
-activities.set('Activity_1u4jwkv', 'Record Invoice Receipt');
-activities.set('Activity_083jf01', 'Remove Payment Block');
-activities.set('Activity_0yabbur', 'Clear Invoice');
+const mainActivities = new Map<string, string>();
+mainActivities.set('Activity_0ec8azh', 'SRM subprocess');
+mainActivities.set('Activity_1t65hvk', 'Create Purchase Order Item');
+mainActivities.set('Activity_06cvihl', 'Record Service Entry Sheet');
+mainActivities.set('Activity_00vbm9s', 'Record Goods Receipts');
+mainActivities.set('Activity_1u4jwkv', 'Record Invoice Receipt');
+mainActivities.set('Activity_083jf01', 'Remove Payment Block');
+mainActivities.set('Activity_0yabbur', 'Clear Invoice');
 
-const gateways = new Map<string, string>();
-gateways.set('Gateway_0xh0plz', 'parallelGatewaySplit1');
-gateways.set('Gateway_0domayw', 'parallelGatewayJoin1');
-gateways.set('Gateway_0apcz1e', 'parallelGatewaySplit2');
-gateways.set('Gateway_01gpztl', 'parallelGatewayJoin2');
-gateways.set('Gateway_08gf298', 'exclusiveGatewaySplit1');
-gateways.set('Gateway_0jqn9hp', 'exclusiveGatewayJoin1');
-gateways.set('Gateway_0a68dfj', 'exclusiveGatewaySplit2');
-gateways.set('Gateway_1ezcj46', 'exclusiveGatewayJoin2');
+const mainGateways = new Map<string, string>();
+mainGateways.set('Gateway_0xh0plz', 'parallelGatewaySplit1');
+mainGateways.set('Gateway_0domayw', 'parallelGatewayJoin1');
+mainGateways.set('Gateway_0apcz1e', 'parallelGatewaySplit2');
+mainGateways.set('Gateway_01gpztl', 'parallelGatewayJoin2');
+mainGateways.set('Gateway_08gf298', 'exclusiveGatewaySplit1');
+mainGateways.set('Gateway_0jqn9hp', 'exclusiveGatewayJoin1');
+mainGateways.set('Gateway_0a68dfj', 'exclusiveGatewaySplit2');
+mainGateways.set('Gateway_1ezcj46', 'exclusiveGatewayJoin2');
 
-const events = new Map<string, string>();
-events.set('Event_1vogvxc', 'New POI Needed');
-events.set('Event_0e43ncy', 'Vendor Creates Invoice');
-events.set('Event_07598zy', 'endEvent');
+const mainEvents = new Map<string, string>();
+mainEvents.set('Event_1vogvxc', 'New POI Needed');
+mainEvents.set('Event_0e43ncy', 'Vendor Creates Invoice');
+mainEvents.set('Event_07598zy', 'endEvent');
 
-export function isActivity(elementId: string): boolean {
-  return activities.has(elementId);
+/*
+  BPMN elements of secondary process
+*/
+const secondaryActivities = new Map<string, string>();
+secondaryActivities.set('Activity_157vm5m', 'SRM: Created');
+secondaryActivities.set('Activity_1243ie0', 'SRM: Complete');
+secondaryActivities.set('Activity_1p3opxc', 'SRM: Awaiting Approval');
+secondaryActivities.set('Activity_015g8ru', 'SRM: Document Completed');
+secondaryActivities.set('Activity_0k8i7cb', 'SRM: Ordered');
+secondaryActivities.set('Activity_0yyl6g2', 'SRM: In Transfer to Execution Syst.');
+secondaryActivities.set('Activity_16tcn1j', 'SRM: Change was Transmitted');
+
+const secondaryGateways = new Map<string, string>();
+secondaryGateways.set('Gateway_0w0fs3j', 'parallelGatewaySplit1');
+secondaryGateways.set('Gateway_1cjjox7', 'parallelGatewayJoin1');
+
+const secondaryEvents = new Map<string, string>();
+secondaryEvents.set('Event_1dnxra5', 'New SRM entry');
+secondaryEvents.set('Event_0bp3ymm', 'endEvent');
+
+export function isActivity(elementId: string, processId: string): boolean {
+  if(processId === "main"){
+    return mainActivities.has(elementId);
+  }
+  else{
+    return secondaryActivities.has(elementId);
+  }
 }
 
-export function isGateway(elementId: string): boolean {
-  return gateways.has(elementId);
+export function isGateway(elementId: string, processId: string): boolean {
+  if(processId === "main"){
+    return mainGateways.has(elementId);
+  }
+  else{
+    return secondaryGateways.has(elementId);
+  }
 }
 
-export function isEvent(elementId: string): boolean {
-  return events.has(elementId);
+export function isEvent(elementId: string, processId: string): boolean {
+  if(processId === "main"){
+    return mainEvents.has(elementId);
+  }
+  else{
+    return secondaryEvents.has(elementId);
+  } 
 }
 
-export function getElementIdByName(elementName: string): string | undefined {
-  for (const [key, value] of activities.entries()) {
-    if (value === elementName) {
-      return key;
-    }
+export function getElementIdByName(elementName: string, processId: string): string | undefined {
+  let activities = new Map<string, string>();
+  let events = new Map<string, string>();
+  if(processId === "main"){
+    activities = mainActivities;
+    events= mainEvents;
+  }
+  else{
+    activities = secondaryActivities;
+    events = secondaryEvents;
   }
 
+  for (const [key, value] of activities.entries()) {
+      if (value === elementName) {
+        return key;
+      }
+  }
   for (const [key, value] of events.entries()) {
     if (value === elementName) {
       return key;
     }
   }
-
   return undefined;
 }

--- a/src/bpmn-elements.ts
+++ b/src/bpmn-elements.ts
@@ -43,53 +43,51 @@ secondaryEvents.set('Event_1dnxra5', 'New SRM entry');
 secondaryEvents.set('Event_0bp3ymm', 'endEvent');
 
 export function isActivity(elementId: string, processId: string): boolean {
-  if(processId === "main"){
+  if (processId === 'main') {
     return mainActivities.has(elementId);
   }
-  else{
-    return secondaryActivities.has(elementId);
-  }
+
+  return secondaryActivities.has(elementId);
 }
 
 export function isGateway(elementId: string, processId: string): boolean {
-  if(processId === "main"){
+  if (processId === 'main') {
     return mainGateways.has(elementId);
   }
-  else{
-    return secondaryGateways.has(elementId);
-  }
+
+  return secondaryGateways.has(elementId);
 }
 
 export function isEvent(elementId: string, processId: string): boolean {
-  if(processId === "main"){
+  if (processId === 'main') {
     return mainEvents.has(elementId);
   }
-  else{
-    return secondaryEvents.has(elementId);
-  } 
+
+  return secondaryEvents.has(elementId);
 }
 
 export function getElementIdByName(elementName: string, processId: string): string | undefined {
   let activities = new Map<string, string>();
   let events = new Map<string, string>();
-  if(processId === "main"){
+  if (processId === 'main') {
     activities = mainActivities;
-    events= mainEvents;
-  }
-  else{
+    events = mainEvents;
+  } else {
     activities = secondaryActivities;
     events = secondaryEvents;
   }
 
   for (const [key, value] of activities.entries()) {
-      if (value === elementName) {
-        return key;
-      }
+    if (value === elementName) {
+      return key;
+    }
   }
+
   for (const [key, value] of events.entries()) {
     if (value === elementName) {
       return key;
     }
   }
+
   return undefined;
 }

--- a/src/bpmn-elements.ts
+++ b/src/bpmn-elements.ts
@@ -66,28 +66,28 @@ export function isEvent(elementId: string, processId: string): boolean {
   return secondaryEvents.has(elementId);
 }
 
-export function getElementIdByName(elementName: string, processId: string): string | undefined {
-  let activities = new Map<string, string>();
-  let events = new Map<string, string>();
-  if (processId === 'main') {
-    activities = mainActivities;
-    events = mainEvents;
-  } else {
-    activities = secondaryActivities;
-    events = secondaryEvents;
-  }
-
-  for (const [key, value] of activities.entries()) {
-    if (value === elementName) {
-      return key;
-    }
-  }
-
-  for (const [key, value] of events.entries()) {
-    if (value === elementName) {
-      return key;
-    }
-  }
-
-  return undefined;
-}
+// Export function getElementIdByName(elementName: string, processId: string): string | undefined {
+//   let activities = new Map<string, string>();
+//   let events = new Map<string, string>();
+//   if (processId === 'main') {
+//     activities = mainActivities;
+//     events = mainEvents;
+//   } else {
+//     activities = secondaryActivities;
+//     events = secondaryEvents;
+//   }
+//
+//   for (const [key, value] of activities.entries()) {
+//     if (value === elementName) {
+//       return key;
+//     }
+//   }
+//
+//   for (const [key, value] of events.entries()) {
+//     if (value === elementName) {
+//       return key;
+//     }
+//   }
+//
+//   return undefined;
+// }

--- a/src/case-monitoring-data.ts
+++ b/src/case-monitoring-data.ts
@@ -1,0 +1,114 @@
+import { BpmnVisualization, EdgeBpmnSemantic, ShapeBpmnSemantic } from 'bpmn-visualization';
+import { getElementIdByName } from './bpmn-elements';
+
+export type CaseMonitoringData = {
+    executedShapes: Set<string>;
+    runningActivities: Set<string>;
+    enabledShapes: Set<string>;
+    pendingShapes: Set<string>;
+    visitedEdges: Set<string>;
+  };
+
+export function getCaseMonitoringData(processId: string, bpmnVisualization: BpmnVisualization, caseId: string = "1"): CaseMonitoringData{
+    const executedShapes = getExecutedShapes(processId, caseId);
+    const runningActivities = getRunningActivities(processId, caseId);
+    const enabledShapes = getEnabledShapes(processId, caseId);
+    const pendingShapes = getPendingShapes(processId, caseId);
+    const visitedEdges = getVisitedEdges(new Set<string>([...executedShapes, ...runningActivities, ...enabledShapes, ...pendingShapes]), bpmnVisualization)
+    return  {
+                executedShapes: executedShapes,
+                runningActivities: runningActivities,
+                enabledShapes: enabledShapes,
+                pendingShapes: pendingShapes,
+                visitedEdges: visitedEdges
+            };
+}
+
+// Already executed shapes: activities, gateways, events, ...
+function getExecutedShapes(processId: string, caseId: string) {
+    if(caseId !== "1"){
+        throw new Error("Case IDs are not supported yet. Keept the default value 1");
+    }
+    const executedShapes = new Set<string>();
+    if(processId == "main"){
+      addNonNullElement(executedShapes, getElementIdByName('New POI Needed', processId)); // Start event
+      addNonNullElement(executedShapes, 'Gateway_0xh0plz'); // Parallel gateway after start event
+      addNonNullElement(executedShapes, getElementIdByName('Vendor Creates Invoice', processId));
+      addNonNullElement(executedShapes, getElementIdByName('Create Purchase Order Item', processId));
+    }
+    //processId = "secondary"
+    else{
+      addNonNullElement(executedShapes, getElementIdByName('New SRM entry', processId)); // Start event
+      addNonNullElement(executedShapes, getElementIdByName('SRM: Created', processId)); 
+      addNonNullElement(executedShapes, getElementIdByName('SRM: Complete', processId));
+        
+    }
+    return executedShapes;
+}
+
+function getRunningActivities(processId: string, caseId: string) {
+    if(caseId !== "1"){
+        throw new Error("Different case IDs are not supported yet. caseID should be kept to default 1");
+    }
+    const runningActivities = new Set<string>();
+    if(processId == "main"){
+        addNonNullElement(runningActivities, getElementIdByName('SRM subprocess', processId));
+    }
+    //no running activities in the secondary subprocess
+    return runningActivities;
+  }
+
+  function getEnabledShapes(processId: string, caseId: string): Set<string> {
+    if(caseId !== "1"){
+        throw new Error("Different case IDs are not supported yet. caseID should be kept to default 1");
+    }
+    const enabledShapes = new Set<string>();
+    if(processId == "secondary"){
+      addNonNullElement(enabledShapes, getElementIdByName('SRM: Awaiting Approval', processId));;
+    }
+    return enabledShapes;
+  }
+  
+  function getPendingShapes(processId: string, caseId: string): Set<string> {
+    if(caseId !== "1"){
+        throw new Error("Different case IDs are not supported yet. caseID should be kept to default 1");
+    }
+    const pendingShapes = new Set<string>();
+    if(processId == "main"){
+        pendingShapes.add('Gateway_0domayw');
+    }
+    return pendingShapes;
+  }
+
+  function getVisitedEdges(shapeIds: Set<string>, bpmnVisualization: BpmnVisualization) {
+    const edgeIds = new Set<string>();
+    for (const shape of shapeIds) {
+      const shapeElt = bpmnVisualization.bpmnElementsRegistry.getElementsByIds(shape)[0];
+      const bpmnSemantic = shapeElt.bpmnSemantic as ShapeBpmnSemantic;
+      const incomingEdges = bpmnSemantic.incomingIds;
+      const outgoingEdges = bpmnSemantic.outgoingIds;
+      for (const edgeId of incomingEdges) {
+        const edgeElement = bpmnVisualization.bpmnElementsRegistry.getElementsByIds(edgeId)[0];
+        const sourceRef = (edgeElement.bpmnSemantic as EdgeBpmnSemantic).sourceRefId;
+        if (shapeIds.has(sourceRef)) {
+          edgeIds.add(edgeId);
+        }
+      }
+  
+      for (const edgeId of outgoingEdges) {
+        const edgeElement = bpmnVisualization.bpmnElementsRegistry.getElementsByIds(edgeId)[0];
+        const targetRef = (edgeElement.bpmnSemantic as EdgeBpmnSemantic).targetRefId;
+        if (shapeIds.has(targetRef)) {
+          edgeIds.add(edgeId);
+        }
+      }
+    }
+  
+    return edgeIds;
+  }
+
+function addNonNullElement(elements: Set<string>, elt: string | undefined) {
+    if (elt) {
+      elements.add(elt);
+    }
+  }

--- a/src/case-monitoring-data.ts
+++ b/src/case-monitoring-data.ts
@@ -1,5 +1,5 @@
 import {type BpmnVisualization} from 'bpmn-visualization';
-import {getElementIdByName} from './bpmn-elements.js';
+import {BpmnElementsSearcher} from './utils/bpmn-elements.js';
 import {PathResolver} from './utils/paths.js';
 
 export type CaseMonitoringData = {
@@ -14,11 +14,11 @@ export type CaseMonitoringData = {
  * Simulate fetching data from an execution system.
  */
 abstract class AbstractCaseMonitoringDataProvider {
+  protected readonly bpmnElementsSearcher: BpmnElementsSearcher;
   private readonly pathResolver: PathResolver;
 
-  // eslint-disable-next-line no-warning-comments -- cannot be managed now
-  // TODO remove the need for processId
-  protected constructor(protected readonly bpmnVisualization: BpmnVisualization, protected readonly processId: string) {
+  protected constructor(protected readonly bpmnVisualization: BpmnVisualization) {
+    this.bpmnElementsSearcher = new BpmnElementsSearcher(bpmnVisualization);
     this.pathResolver = new PathResolver(bpmnVisualization);
   }
 
@@ -52,7 +52,7 @@ abstract class AbstractCaseMonitoringDataProvider {
 
 class MainProcessCaseMonitoringDataProvider extends AbstractCaseMonitoringDataProvider {
   constructor(protected readonly bpmnVisualization: BpmnVisualization) {
-    super(bpmnVisualization, 'main');
+    super(bpmnVisualization);
   }
 
   getEnabledShapes(): string[] {
@@ -61,10 +61,10 @@ class MainProcessCaseMonitoringDataProvider extends AbstractCaseMonitoringDataPr
 
   getExecutedShapes(): string[] {
     const shapes: string[] = [];
-    addNonNullElement(shapes, getElementIdByName('New POI Needed', this.processId)); // Start event
+    addNonNullElement(shapes, this.bpmnElementsSearcher.getElementIdByName('New POI needed')); // Start event
     addNonNullElement(shapes, 'Gateway_0xh0plz'); // Parallel gateway after start event
-    addNonNullElement(shapes, getElementIdByName('Vendor Creates Invoice', this.processId));
-    addNonNullElement(shapes, getElementIdByName('Create Purchase Order Item', this.processId));
+    addNonNullElement(shapes, this.bpmnElementsSearcher.getElementIdByName('Vendor creates invoice'));
+    addNonNullElement(shapes, this.bpmnElementsSearcher.getElementIdByName('Create Purchase Order Item'));
     return shapes;
   }
 
@@ -76,27 +76,27 @@ class MainProcessCaseMonitoringDataProvider extends AbstractCaseMonitoringDataPr
 
   getRunningActivities(): string[] {
     const activities: string[] = [];
-    addNonNullElement(activities, getElementIdByName('SRM subprocess', this.processId));
+    addNonNullElement(activities, this.bpmnElementsSearcher.getElementIdByName('SRM subprocess'));
     return activities;
   }
 }
 
 class SecondaryProcessCaseMonitoringDataProvider extends AbstractCaseMonitoringDataProvider {
   constructor(protected readonly bpmnVisualization: BpmnVisualization) {
-    super(bpmnVisualization, 'secondary');
+    super(bpmnVisualization);
   }
 
   getEnabledShapes(): string[] {
     const shapes: string[] = [];
-    addNonNullElement(shapes, getElementIdByName('SRM: Awaiting Approval', this.processId));
+    addNonNullElement(shapes, this.bpmnElementsSearcher.getElementIdByName('SRM: Awaiting Approval'));
     return shapes;
   }
 
   getExecutedShapes(): string[] {
     const shapes: string[] = [];
-    addNonNullElement(shapes, getElementIdByName('New SRM entry', this.processId)); // Start event
-    addNonNullElement(shapes, getElementIdByName('SRM: Created', this.processId));
-    addNonNullElement(shapes, getElementIdByName('SRM: Complete', this.processId));
+    addNonNullElement(shapes, 'Event_1dnxra5'); // Start event
+    addNonNullElement(shapes, this.bpmnElementsSearcher.getElementIdByName('SRM: Created'));
+    addNonNullElement(shapes, this.bpmnElementsSearcher.getElementIdByName('SRM: Complete'));
     return shapes;
   }
 

--- a/src/case-monitoring-data.ts
+++ b/src/case-monitoring-data.ts
@@ -127,67 +127,6 @@ export function getCaseMonitoringData(processId: string, bpmnVisualization: Bpmn
   };
 }
 
-// Already executed shapes: activities, gateways, events, ...
-// function getExecutedShapes(processId: string, caseId: string) {
-//   if (caseId !== '1') {
-//     throw new Error('Case IDs are not supported yet. caseID should be kept to default 1');
-//   }
-//
-//   const executedShapes: string[] = [];
-//   if (processId === 'main') {
-//     addNonNullElement(executedShapes, getElementIdByName('New POI Needed', processId)); // Start event
-//     addNonNullElement(executedShapes, 'Gateway_0xh0plz'); // Parallel gateway after start event
-//     addNonNullElement(executedShapes, getElementIdByName('Vendor Creates Invoice', processId));
-//     addNonNullElement(executedShapes, getElementIdByName('Create Purchase Order Item', processId));
-//   } else {
-//     addNonNullElement(executedShapes, getElementIdByName('New SRM entry', processId)); // Start event
-//     addNonNullElement(executedShapes, getElementIdByName('SRM: Created', processId));
-//     addNonNullElement(executedShapes, getElementIdByName('SRM: Complete', processId));
-//   }
-//
-//   return executedShapes;
-// }
-//
-// function getRunningActivities(processId: string, caseId: string) {
-//   if (caseId !== '1') {
-//     throw new Error('Different case IDs are not supported yet. caseID should be kept to default 1');
-//   }
-//
-//   const runningActivities: string[] = [];
-//   if (processId === 'main') {
-//     addNonNullElement(runningActivities, getElementIdByName('SRM subprocess', processId));
-//   }
-//
-//   // No running activities in the secondary subprocess
-//   return runningActivities;
-// }
-//
-// function getEnabledShapes(processId: string, caseId: string) {
-//   if (caseId !== '1') {
-//     throw new Error('Different case IDs are not supported yet. caseID should be kept to default 1');
-//   }
-//
-//   const enabledShapes: string[] = [];
-//   if (processId === 'secondary') {
-//     addNonNullElement(enabledShapes, getElementIdByName('SRM: Awaiting Approval', processId));
-//   }
-//
-//   return enabledShapes;
-// }
-//
-// function getPendingShapes(processId: string, caseId: string) {
-//   if (caseId !== '1') {
-//     throw new Error('Different case IDs are not supported yet. caseID should be kept to default 1');
-//   }
-//
-//   const pendingShapes: string[] = [];
-//   if (processId === 'main') {
-//     pendingShapes.push('Gateway_0domayw');
-//   }
-//
-//   return pendingShapes;
-// }
-
 function addNonNullElement(elements: string[], elt: string | undefined) {
   if (elt) {
     elements.push(elt);

--- a/src/case-monitoring-data.ts
+++ b/src/case-monitoring-data.ts
@@ -15,10 +15,16 @@ export type CaseMonitoringData = {
  */
 abstract class AbstractCaseMonitoringDataProvider {
   private readonly pathResolver: PathResolver;
-  protected constructor(protected readonly bpmnVisualization: BpmnVisualization) {
+
+  // eslint-disable-next-line no-warning-comments -- cannot be managed now
+  // TODO remove the need for processId
+  protected constructor(protected readonly bpmnVisualization: BpmnVisualization, protected readonly processId: string) {
     this.pathResolver = new PathResolver(bpmnVisualization);
   }
 
+  /**
+   * In real life, parameters would be passed to this method, at least the `case id`.
+   */
   fetch(): CaseMonitoringData {
     const executedShapes = this.getExecutedShapes();
     const runningActivities = this.getRunningActivities();
@@ -35,20 +41,81 @@ abstract class AbstractCaseMonitoringDataProvider {
     };
   }
 
-  protected abstract getExecutedShapes(): string[];
+  abstract getExecutedShapes(): string[];
 
-  protected abstract getRunningActivities(): string[];
+  abstract getRunningActivities(): string[];
 
-  protected abstract getEnabledShapes(): string[];
+  abstract getEnabledShapes(): string[];
 
-  protected abstract getPendingShapes(): string[];
+  abstract getPendingShapes(): string[];
 }
 
-export function getCaseMonitoringData(processId: string, bpmnVisualization: BpmnVisualization, caseId = '1'): CaseMonitoringData {
-  const executedShapes = getExecutedShapes(processId, caseId);
-  const runningActivities = getRunningActivities(processId, caseId);
-  const enabledShapes = getEnabledShapes(processId, caseId);
-  const pendingShapes = getPendingShapes(processId, caseId);
+class MainProcessCaseMonitoringDataProvider extends AbstractCaseMonitoringDataProvider {
+  constructor(protected readonly bpmnVisualization: BpmnVisualization) {
+    super(bpmnVisualization, 'main');
+  }
+
+  getEnabledShapes(): string[] {
+    return [];
+  }
+
+  getExecutedShapes(): string[] {
+    const shapes: string[] = [];
+    addNonNullElement(shapes, getElementIdByName('New POI Needed', this.processId)); // Start event
+    addNonNullElement(shapes, 'Gateway_0xh0plz'); // Parallel gateway after start event
+    addNonNullElement(shapes, getElementIdByName('Vendor Creates Invoice', this.processId));
+    addNonNullElement(shapes, getElementIdByName('Create Purchase Order Item', this.processId));
+    return shapes;
+  }
+
+  getPendingShapes(): string[] {
+    const pendingShapes: string[] = [];
+    pendingShapes.push('Gateway_0domayw');
+    return pendingShapes;
+  }
+
+  getRunningActivities(): string[] {
+    const activities: string[] = [];
+    addNonNullElement(activities, getElementIdByName('SRM subprocess', this.processId));
+    return activities;
+  }
+}
+
+class SecondaryProcessCaseMonitoringDataProvider extends AbstractCaseMonitoringDataProvider {
+  constructor(protected readonly bpmnVisualization: BpmnVisualization) {
+    super(bpmnVisualization, 'secondary');
+  }
+
+  getEnabledShapes(): string[] {
+    const shapes: string[] = [];
+    addNonNullElement(shapes, getElementIdByName('SRM: Awaiting Approval', this.processId));
+    return shapes;
+  }
+
+  getExecutedShapes(): string[] {
+    const shapes: string[] = [];
+    addNonNullElement(shapes, getElementIdByName('New SRM entry', this.processId)); // Start event
+    addNonNullElement(shapes, getElementIdByName('SRM: Created', this.processId));
+    addNonNullElement(shapes, getElementIdByName('SRM: Complete', this.processId));
+    return shapes;
+  }
+
+  getPendingShapes(): string[] {
+    return [];
+  }
+
+  getRunningActivities(): string[] {
+    return [];
+  }
+}
+
+export function getCaseMonitoringData(processId: string, bpmnVisualization: BpmnVisualization): CaseMonitoringData {
+  const caseMonitoringDataProvider = processId === 'main' ? new MainProcessCaseMonitoringDataProvider(bpmnVisualization) : new SecondaryProcessCaseMonitoringDataProvider(bpmnVisualization);
+
+  const executedShapes = caseMonitoringDataProvider.getExecutedShapes();
+  const runningActivities = caseMonitoringDataProvider.getRunningActivities();
+  const enabledShapes = caseMonitoringDataProvider.getEnabledShapes();
+  const pendingShapes = caseMonitoringDataProvider.getPendingShapes();
 
   const visitedEdges = new PathResolver(bpmnVisualization).getVisitedEdges([...executedShapes, ...runningActivities, ...enabledShapes, ...pendingShapes]);
   return {
@@ -61,65 +128,65 @@ export function getCaseMonitoringData(processId: string, bpmnVisualization: Bpmn
 }
 
 // Already executed shapes: activities, gateways, events, ...
-function getExecutedShapes(processId: string, caseId: string) {
-  if (caseId !== '1') {
-    throw new Error('Case IDs are not supported yet. caseID should be kept to default 1');
-  }
-
-  const executedShapes: string[] = [];
-  if (processId === 'main') {
-    addNonNullElement(executedShapes, getElementIdByName('New POI Needed', processId)); // Start event
-    addNonNullElement(executedShapes, 'Gateway_0xh0plz'); // Parallel gateway after start event
-    addNonNullElement(executedShapes, getElementIdByName('Vendor Creates Invoice', processId));
-    addNonNullElement(executedShapes, getElementIdByName('Create Purchase Order Item', processId));
-  } else {
-    addNonNullElement(executedShapes, getElementIdByName('New SRM entry', processId)); // Start event
-    addNonNullElement(executedShapes, getElementIdByName('SRM: Created', processId));
-    addNonNullElement(executedShapes, getElementIdByName('SRM: Complete', processId));
-  }
-
-  return executedShapes;
-}
-
-function getRunningActivities(processId: string, caseId: string) {
-  if (caseId !== '1') {
-    throw new Error('Different case IDs are not supported yet. caseID should be kept to default 1');
-  }
-
-  const runningActivities: string[] = [];
-  if (processId === 'main') {
-    addNonNullElement(runningActivities, getElementIdByName('SRM subprocess', processId));
-  }
-
-  // No running activities in the secondary subprocess
-  return runningActivities;
-}
-
-function getEnabledShapes(processId: string, caseId: string) {
-  if (caseId !== '1') {
-    throw new Error('Different case IDs are not supported yet. caseID should be kept to default 1');
-  }
-
-  const enabledShapes: string[] = [];
-  if (processId === 'secondary') {
-    addNonNullElement(enabledShapes, getElementIdByName('SRM: Awaiting Approval', processId));
-  }
-
-  return enabledShapes;
-}
-
-function getPendingShapes(processId: string, caseId: string) {
-  if (caseId !== '1') {
-    throw new Error('Different case IDs are not supported yet. caseID should be kept to default 1');
-  }
-
-  const pendingShapes: string[] = [];
-  if (processId === 'main') {
-    pendingShapes.push('Gateway_0domayw');
-  }
-
-  return pendingShapes;
-}
+// function getExecutedShapes(processId: string, caseId: string) {
+//   if (caseId !== '1') {
+//     throw new Error('Case IDs are not supported yet. caseID should be kept to default 1');
+//   }
+//
+//   const executedShapes: string[] = [];
+//   if (processId === 'main') {
+//     addNonNullElement(executedShapes, getElementIdByName('New POI Needed', processId)); // Start event
+//     addNonNullElement(executedShapes, 'Gateway_0xh0plz'); // Parallel gateway after start event
+//     addNonNullElement(executedShapes, getElementIdByName('Vendor Creates Invoice', processId));
+//     addNonNullElement(executedShapes, getElementIdByName('Create Purchase Order Item', processId));
+//   } else {
+//     addNonNullElement(executedShapes, getElementIdByName('New SRM entry', processId)); // Start event
+//     addNonNullElement(executedShapes, getElementIdByName('SRM: Created', processId));
+//     addNonNullElement(executedShapes, getElementIdByName('SRM: Complete', processId));
+//   }
+//
+//   return executedShapes;
+// }
+//
+// function getRunningActivities(processId: string, caseId: string) {
+//   if (caseId !== '1') {
+//     throw new Error('Different case IDs are not supported yet. caseID should be kept to default 1');
+//   }
+//
+//   const runningActivities: string[] = [];
+//   if (processId === 'main') {
+//     addNonNullElement(runningActivities, getElementIdByName('SRM subprocess', processId));
+//   }
+//
+//   // No running activities in the secondary subprocess
+//   return runningActivities;
+// }
+//
+// function getEnabledShapes(processId: string, caseId: string) {
+//   if (caseId !== '1') {
+//     throw new Error('Different case IDs are not supported yet. caseID should be kept to default 1');
+//   }
+//
+//   const enabledShapes: string[] = [];
+//   if (processId === 'secondary') {
+//     addNonNullElement(enabledShapes, getElementIdByName('SRM: Awaiting Approval', processId));
+//   }
+//
+//   return enabledShapes;
+// }
+//
+// function getPendingShapes(processId: string, caseId: string) {
+//   if (caseId !== '1') {
+//     throw new Error('Different case IDs are not supported yet. caseID should be kept to default 1');
+//   }
+//
+//   const pendingShapes: string[] = [];
+//   if (processId === 'main') {
+//     pendingShapes.push('Gateway_0domayw');
+//   }
+//
+//   return pendingShapes;
+// }
 
 function addNonNullElement(elements: string[], elt: string | undefined) {
   if (elt) {

--- a/src/case-monitoring-data.ts
+++ b/src/case-monitoring-data.ts
@@ -2,11 +2,11 @@ import {type BpmnVisualization, type EdgeBpmnSemantic, type ShapeBpmnSemantic} f
 import {getElementIdByName} from './bpmn-elements.js';
 
 export type CaseMonitoringData = {
-  executedShapes: Set<string>;
-  runningActivities: Set<string>;
-  enabledShapes: Set<string>;
-  pendingShapes: Set<string>;
-  visitedEdges: Set<string>;
+  executedShapes: string[];
+  runningActivities: string[];
+  enabledShapes: string[];
+  pendingShapes: string[];
+  visitedEdges: string[];
 };
 
 export function getCaseMonitoringData(processId: string, bpmnVisualization: BpmnVisualization, caseId = '1'): CaseMonitoringData {
@@ -14,7 +14,8 @@ export function getCaseMonitoringData(processId: string, bpmnVisualization: Bpmn
   const runningActivities = getRunningActivities(processId, caseId);
   const enabledShapes = getEnabledShapes(processId, caseId);
   const pendingShapes = getPendingShapes(processId, caseId);
-  const visitedEdges = getVisitedEdges(new Set<string>([...executedShapes, ...runningActivities, ...enabledShapes, ...pendingShapes]), bpmnVisualization);
+
+  const visitedEdges = Array.from(getVisitedEdges(new Set<string>([...executedShapes, ...runningActivities, ...enabledShapes, ...pendingShapes]), bpmnVisualization));
   return {
     executedShapes,
     runningActivities,
@@ -27,10 +28,10 @@ export function getCaseMonitoringData(processId: string, bpmnVisualization: Bpmn
 // Already executed shapes: activities, gateways, events, ...
 function getExecutedShapes(processId: string, caseId: string) {
   if (caseId !== '1') {
-    throw new Error('Case IDs are not supported yet. Keept the default value 1');
+    throw new Error('Case IDs are not supported yet. caseID should be kept to default 1');
   }
 
-  const executedShapes = new Set<string>();
+  const executedShapes: string[] = [];
   if (processId === 'main') {
     addNonNullElement(executedShapes, getElementIdByName('New POI Needed', processId)); // Start event
     addNonNullElement(executedShapes, 'Gateway_0xh0plz'); // Parallel gateway after start event
@@ -50,7 +51,7 @@ function getRunningActivities(processId: string, caseId: string) {
     throw new Error('Different case IDs are not supported yet. caseID should be kept to default 1');
   }
 
-  const runningActivities = new Set<string>();
+  const runningActivities: string[] = [];
   if (processId === 'main') {
     addNonNullElement(runningActivities, getElementIdByName('SRM subprocess', processId));
   }
@@ -59,12 +60,12 @@ function getRunningActivities(processId: string, caseId: string) {
   return runningActivities;
 }
 
-function getEnabledShapes(processId: string, caseId: string): Set<string> {
+function getEnabledShapes(processId: string, caseId: string) {
   if (caseId !== '1') {
     throw new Error('Different case IDs are not supported yet. caseID should be kept to default 1');
   }
 
-  const enabledShapes = new Set<string>();
+  const enabledShapes: string[] = [];
   if (processId === 'secondary') {
     addNonNullElement(enabledShapes, getElementIdByName('SRM: Awaiting Approval', processId));
   }
@@ -72,14 +73,14 @@ function getEnabledShapes(processId: string, caseId: string): Set<string> {
   return enabledShapes;
 }
 
-function getPendingShapes(processId: string, caseId: string): Set<string> {
+function getPendingShapes(processId: string, caseId: string) {
   if (caseId !== '1') {
     throw new Error('Different case IDs are not supported yet. caseID should be kept to default 1');
   }
 
-  const pendingShapes = new Set<string>();
+  const pendingShapes: string[] = [];
   if (processId === 'main') {
-    pendingShapes.add('Gateway_0domayw');
+    pendingShapes.push('Gateway_0domayw');
   }
 
   return pendingShapes;
@@ -112,8 +113,8 @@ function getVisitedEdges(shapeIds: Set<string>, bpmnVisualization: BpmnVisualiza
   return edgeIds;
 }
 
-function addNonNullElement(elements: Set<string>, elt: string | undefined) {
+function addNonNullElement(elements: string[], elt: string | undefined) {
   if (elt) {
-    elements.add(elt);
+    elements.push(elt);
   }
 }

--- a/src/case-monitoring-data.ts
+++ b/src/case-monitoring-data.ts
@@ -1,114 +1,119 @@
-import { BpmnVisualization, EdgeBpmnSemantic, ShapeBpmnSemantic } from 'bpmn-visualization';
-import { getElementIdByName } from './bpmn-elements';
+import {type BpmnVisualization, type EdgeBpmnSemantic, type ShapeBpmnSemantic} from 'bpmn-visualization';
+import {getElementIdByName} from './bpmn-elements.js';
 
 export type CaseMonitoringData = {
-    executedShapes: Set<string>;
-    runningActivities: Set<string>;
-    enabledShapes: Set<string>;
-    pendingShapes: Set<string>;
-    visitedEdges: Set<string>;
-  };
+  executedShapes: Set<string>;
+  runningActivities: Set<string>;
+  enabledShapes: Set<string>;
+  pendingShapes: Set<string>;
+  visitedEdges: Set<string>;
+};
 
-export function getCaseMonitoringData(processId: string, bpmnVisualization: BpmnVisualization, caseId: string = "1"): CaseMonitoringData{
-    const executedShapes = getExecutedShapes(processId, caseId);
-    const runningActivities = getRunningActivities(processId, caseId);
-    const enabledShapes = getEnabledShapes(processId, caseId);
-    const pendingShapes = getPendingShapes(processId, caseId);
-    const visitedEdges = getVisitedEdges(new Set<string>([...executedShapes, ...runningActivities, ...enabledShapes, ...pendingShapes]), bpmnVisualization)
-    return  {
-                executedShapes: executedShapes,
-                runningActivities: runningActivities,
-                enabledShapes: enabledShapes,
-                pendingShapes: pendingShapes,
-                visitedEdges: visitedEdges
-            };
+export function getCaseMonitoringData(processId: string, bpmnVisualization: BpmnVisualization, caseId = '1'): CaseMonitoringData {
+  const executedShapes = getExecutedShapes(processId, caseId);
+  const runningActivities = getRunningActivities(processId, caseId);
+  const enabledShapes = getEnabledShapes(processId, caseId);
+  const pendingShapes = getPendingShapes(processId, caseId);
+  const visitedEdges = getVisitedEdges(new Set<string>([...executedShapes, ...runningActivities, ...enabledShapes, ...pendingShapes]), bpmnVisualization);
+  return {
+    executedShapes,
+    runningActivities,
+    enabledShapes,
+    pendingShapes,
+    visitedEdges,
+  };
 }
 
 // Already executed shapes: activities, gateways, events, ...
 function getExecutedShapes(processId: string, caseId: string) {
-    if(caseId !== "1"){
-        throw new Error("Case IDs are not supported yet. Keept the default value 1");
-    }
-    const executedShapes = new Set<string>();
-    if(processId == "main"){
-      addNonNullElement(executedShapes, getElementIdByName('New POI Needed', processId)); // Start event
-      addNonNullElement(executedShapes, 'Gateway_0xh0plz'); // Parallel gateway after start event
-      addNonNullElement(executedShapes, getElementIdByName('Vendor Creates Invoice', processId));
-      addNonNullElement(executedShapes, getElementIdByName('Create Purchase Order Item', processId));
-    }
-    //processId = "secondary"
-    else{
-      addNonNullElement(executedShapes, getElementIdByName('New SRM entry', processId)); // Start event
-      addNonNullElement(executedShapes, getElementIdByName('SRM: Created', processId)); 
-      addNonNullElement(executedShapes, getElementIdByName('SRM: Complete', processId));
-        
-    }
-    return executedShapes;
+  if (caseId !== '1') {
+    throw new Error('Case IDs are not supported yet. Keept the default value 1');
+  }
+
+  const executedShapes = new Set<string>();
+  if (processId === 'main') {
+    addNonNullElement(executedShapes, getElementIdByName('New POI Needed', processId)); // Start event
+    addNonNullElement(executedShapes, 'Gateway_0xh0plz'); // Parallel gateway after start event
+    addNonNullElement(executedShapes, getElementIdByName('Vendor Creates Invoice', processId));
+    addNonNullElement(executedShapes, getElementIdByName('Create Purchase Order Item', processId));
+  } else {
+    addNonNullElement(executedShapes, getElementIdByName('New SRM entry', processId)); // Start event
+    addNonNullElement(executedShapes, getElementIdByName('SRM: Created', processId));
+    addNonNullElement(executedShapes, getElementIdByName('SRM: Complete', processId));
+  }
+
+  return executedShapes;
 }
 
 function getRunningActivities(processId: string, caseId: string) {
-    if(caseId !== "1"){
-        throw new Error("Different case IDs are not supported yet. caseID should be kept to default 1");
-    }
-    const runningActivities = new Set<string>();
-    if(processId == "main"){
-        addNonNullElement(runningActivities, getElementIdByName('SRM subprocess', processId));
-    }
-    //no running activities in the secondary subprocess
-    return runningActivities;
+  if (caseId !== '1') {
+    throw new Error('Different case IDs are not supported yet. caseID should be kept to default 1');
   }
 
-  function getEnabledShapes(processId: string, caseId: string): Set<string> {
-    if(caseId !== "1"){
-        throw new Error("Different case IDs are not supported yet. caseID should be kept to default 1");
-    }
-    const enabledShapes = new Set<string>();
-    if(processId == "secondary"){
-      addNonNullElement(enabledShapes, getElementIdByName('SRM: Awaiting Approval', processId));;
-    }
-    return enabledShapes;
-  }
-  
-  function getPendingShapes(processId: string, caseId: string): Set<string> {
-    if(caseId !== "1"){
-        throw new Error("Different case IDs are not supported yet. caseID should be kept to default 1");
-    }
-    const pendingShapes = new Set<string>();
-    if(processId == "main"){
-        pendingShapes.add('Gateway_0domayw');
-    }
-    return pendingShapes;
+  const runningActivities = new Set<string>();
+  if (processId === 'main') {
+    addNonNullElement(runningActivities, getElementIdByName('SRM subprocess', processId));
   }
 
-  function getVisitedEdges(shapeIds: Set<string>, bpmnVisualization: BpmnVisualization) {
-    const edgeIds = new Set<string>();
-    for (const shape of shapeIds) {
-      const shapeElt = bpmnVisualization.bpmnElementsRegistry.getElementsByIds(shape)[0];
-      const bpmnSemantic = shapeElt.bpmnSemantic as ShapeBpmnSemantic;
-      const incomingEdges = bpmnSemantic.incomingIds;
-      const outgoingEdges = bpmnSemantic.outgoingIds;
-      for (const edgeId of incomingEdges) {
-        const edgeElement = bpmnVisualization.bpmnElementsRegistry.getElementsByIds(edgeId)[0];
-        const sourceRef = (edgeElement.bpmnSemantic as EdgeBpmnSemantic).sourceRefId;
-        if (shapeIds.has(sourceRef)) {
-          edgeIds.add(edgeId);
-        }
-      }
-  
-      for (const edgeId of outgoingEdges) {
-        const edgeElement = bpmnVisualization.bpmnElementsRegistry.getElementsByIds(edgeId)[0];
-        const targetRef = (edgeElement.bpmnSemantic as EdgeBpmnSemantic).targetRefId;
-        if (shapeIds.has(targetRef)) {
-          edgeIds.add(edgeId);
-        }
+  // No running activities in the secondary subprocess
+  return runningActivities;
+}
+
+function getEnabledShapes(processId: string, caseId: string): Set<string> {
+  if (caseId !== '1') {
+    throw new Error('Different case IDs are not supported yet. caseID should be kept to default 1');
+  }
+
+  const enabledShapes = new Set<string>();
+  if (processId === 'secondary') {
+    addNonNullElement(enabledShapes, getElementIdByName('SRM: Awaiting Approval', processId));
+  }
+
+  return enabledShapes;
+}
+
+function getPendingShapes(processId: string, caseId: string): Set<string> {
+  if (caseId !== '1') {
+    throw new Error('Different case IDs are not supported yet. caseID should be kept to default 1');
+  }
+
+  const pendingShapes = new Set<string>();
+  if (processId === 'main') {
+    pendingShapes.add('Gateway_0domayw');
+  }
+
+  return pendingShapes;
+}
+
+function getVisitedEdges(shapeIds: Set<string>, bpmnVisualization: BpmnVisualization) {
+  const edgeIds = new Set<string>();
+  for (const shape of shapeIds) {
+    const shapeElt = bpmnVisualization.bpmnElementsRegistry.getElementsByIds(shape)[0];
+    const bpmnSemantic = shapeElt.bpmnSemantic as ShapeBpmnSemantic;
+    const incomingEdges = bpmnSemantic.incomingIds;
+    const outgoingEdges = bpmnSemantic.outgoingIds;
+    for (const edgeId of incomingEdges) {
+      const edgeElement = bpmnVisualization.bpmnElementsRegistry.getElementsByIds(edgeId)[0];
+      const sourceRef = (edgeElement.bpmnSemantic as EdgeBpmnSemantic).sourceRefId;
+      if (shapeIds.has(sourceRef)) {
+        edgeIds.add(edgeId);
       }
     }
-  
-    return edgeIds;
+
+    for (const edgeId of outgoingEdges) {
+      const edgeElement = bpmnVisualization.bpmnElementsRegistry.getElementsByIds(edgeId)[0];
+      const targetRef = (edgeElement.bpmnSemantic as EdgeBpmnSemantic).targetRefId;
+      if (shapeIds.has(targetRef)) {
+        edgeIds.add(edgeId);
+      }
+    }
   }
+
+  return edgeIds;
+}
 
 function addNonNullElement(elements: Set<string>, elt: string | undefined) {
-    if (elt) {
-      elements.add(elt);
-    }
+  if (elt) {
+    elements.add(elt);
   }
+}

--- a/src/case-monitoring-data.ts
+++ b/src/case-monitoring-data.ts
@@ -10,6 +10,40 @@ export type CaseMonitoringData = {
   visitedEdges: string[];
 };
 
+/**
+ * Simulate fetching data from an execution system.
+ */
+abstract class AbstractCaseMonitoringDataProvider {
+  private readonly pathResolver: PathResolver;
+  protected constructor(protected readonly bpmnVisualization: BpmnVisualization) {
+    this.pathResolver = new PathResolver(bpmnVisualization);
+  }
+
+  fetch(): CaseMonitoringData {
+    const executedShapes = this.getExecutedShapes();
+    const runningActivities = this.getRunningActivities();
+    const enabledShapes = this.getEnabledShapes();
+    const pendingShapes = this.getPendingShapes();
+
+    const visitedEdges = this.pathResolver.getVisitedEdges([...executedShapes, ...runningActivities, ...enabledShapes, ...pendingShapes]);
+    return {
+      executedShapes,
+      runningActivities,
+      enabledShapes,
+      pendingShapes,
+      visitedEdges,
+    };
+  }
+
+  protected abstract getExecutedShapes(): string[];
+
+  protected abstract getRunningActivities(): string[];
+
+  protected abstract getEnabledShapes(): string[];
+
+  protected abstract getPendingShapes(): string[];
+}
+
 export function getCaseMonitoringData(processId: string, bpmnVisualization: BpmnVisualization, caseId = '1'): CaseMonitoringData {
   const executedShapes = getExecutedShapes(processId, caseId);
   const runningActivities = getRunningActivities(processId, caseId);

--- a/src/case-monitoring.ts
+++ b/src/case-monitoring.ts
@@ -111,7 +111,7 @@ function addPopover(activityId: string, bpmnVisualization: BpmnVisualization) {
         instance.setContent(getRecommendationInfoAsHtml(instance.reference));
       } else {
         instance.setContent(getWarningInfoAsHtml());
-        // instance.setContent(getWarningInfoAsHtml(instance.reference));
+        // Instance.setContent(getWarningInfoAsHtml(instance.reference));
       }
     },
   } as Partial<Props>);
@@ -140,7 +140,7 @@ function addPopover(activityId: string, bpmnVisualization: BpmnVisualization) {
     });
   }
 
-
+  // eslint-disable-next-line no-warning-comments -- cannot be managed now
   // TODO use CSS classes to handle hover on table within the tippy instance
   // Add mouseover and mouseout event listeners to the table rows
   tippyInstance.popper.addEventListener('mouseover', (event: Event) => {
@@ -212,7 +212,7 @@ function getRecommendationInfoAsHtml(htmlElement: ReferenceElement) {
 }
 
 function getWarningInfoAsHtml() {
-// function getWarningInfoAsHtml(htmlElement: ReferenceElement) {
+// Function getWarningInfoAsHtml(htmlElement: ReferenceElement) {
   return `
         <div class="popover-container">
           <h4>Resource not available</h4>
@@ -279,7 +279,7 @@ function showResourceAllocationAction() {
     popoverInstance.popper.addEventListener('mouseover', (event: MouseEvent) => {
       const target = event.target as HTMLElement;
       console.info('listener mouseover, target', target);
-      // if (target.nodeName === 'TD') {
+      // If (target.nodeName === 'TD') {
       //   const selectedRow = target.parentElement as HTMLTableRowElement;
       // }
     });

--- a/src/case-monitoring.ts
+++ b/src/case-monitoring.ts
@@ -30,37 +30,37 @@ export function hideCaseMonitoringData(processId: string, bpmnVisualization: Bpm
 }
 
 function reduceVisibilityOfAlreadyExecutedElements(bpmnVisualization: BpmnVisualization) {
-  bpmnVisualization.bpmnElementsRegistry.addCssClasses(Array.from([...caseMonitoringData.executedShapes, ...caseMonitoringData.visitedEdges]), 'state-already-executed');
+  bpmnVisualization.bpmnElementsRegistry.addCssClasses([...caseMonitoringData.executedShapes, ...caseMonitoringData.visitedEdges], 'state-already-executed');
 }
 
 function restoreVisibilityOfAlreadyExecutedElements(bpmnVisualization: BpmnVisualization) {
   // eslint-disable-next-line no-warning-comments -- question to answer by Nour
   // TODO why adding pending?  the CSS class was not added in reduceVisibilityOfAlreadyExecutedElements
-  bpmnVisualization.bpmnElementsRegistry.removeCssClasses(Array.from([...caseMonitoringData.executedShapes, ...caseMonitoringData.pendingShapes, ...caseMonitoringData.visitedEdges]), 'state-already-executed');
+  bpmnVisualization.bpmnElementsRegistry.removeCssClasses([...caseMonitoringData.executedShapes, ...caseMonitoringData.pendingShapes, ...caseMonitoringData.visitedEdges], 'state-already-executed');
 }
 
 // eslint-disable-next-line no-warning-comments -- cannot be managed now
 // TODO: rename CSS class
 function highlightRunningElements(bpmnVisualization: BpmnVisualization) {
-  const runningActivities = Array.from(caseMonitoringData.runningActivities);
-  bpmnVisualization.bpmnElementsRegistry.addCssClasses(runningActivities, 'state-running-late');
+  const elements = caseMonitoringData.runningActivities;
+  bpmnVisualization.bpmnElementsRegistry.addCssClasses(elements, 'state-running-late');
   if (currentView === 'main') {
-    addInfoOnRunningElements(runningActivities, bpmnVisualization);
+    addInfoOnRunningElements(elements, bpmnVisualization);
   }
 }
 
 export function highlightEnabledElements(bpmnVisualization: BpmnVisualization) {
-  const enabledActivities = Array.from(caseMonitoringData.enabledShapes);
-  bpmnVisualization.bpmnElementsRegistry.addCssClasses(enabledActivities, 'state-enabled');
+  const elements = caseMonitoringData.enabledShapes;
+  bpmnVisualization.bpmnElementsRegistry.addCssClasses(elements, 'state-enabled');
   if (currentView === 'secondary') {
-    addInfoOnEnabledElements(enabledActivities, bpmnVisualization);
+    addInfoOnEnabledElements(elements, bpmnVisualization);
   }
 }
 
 function resetRunningElements(bpmnVisualization: BpmnVisualization) {
-  const runningActivities = Array.from(caseMonitoringData.runningActivities);
-  bpmnVisualization.bpmnElementsRegistry.removeCssClasses(runningActivities, 'state-running-late');
-  for (const activityId of runningActivities) {
+  const elements = caseMonitoringData.runningActivities;
+  bpmnVisualization.bpmnElementsRegistry.removeCssClasses(elements, 'state-running-late');
+  for (const activityId of elements) {
     bpmnVisualization.bpmnElementsRegistry.removeAllOverlays(activityId);
   }
 
@@ -72,25 +72,25 @@ function resetRunningElements(bpmnVisualization: BpmnVisualization) {
   tippyInstances.length = 0;
 }
 
-function addInfoOnRunningElements(runningActivities: string[], bpmnVisualization: BpmnVisualization) {
-  for (const activityId of runningActivities) {
-    addPopover(activityId, bpmnVisualization);
-    addOverlay(activityId, bpmnVisualization);
+function addInfoOnRunningElements(bpmnElementIds: string[], bpmnVisualization: BpmnVisualization) {
+  for (const bpmnElementId of bpmnElementIds) {
+    addPopover(bpmnElementId, bpmnVisualization);
+    addOverlay(bpmnElementId, bpmnVisualization);
   }
 }
 
-function addInfoOnEnabledElements(enabledActivities: string[], bpmnVisualization: BpmnVisualization) {
-  for (const activityId of enabledActivities) {
-    addPopover(activityId, bpmnVisualization);
-    addOverlay(activityId, bpmnVisualization);
+function addInfoOnEnabledElements(bpmnElementIds: string[], bpmnVisualization: BpmnVisualization) {
+  for (const bpmnElementId of bpmnElementIds) {
+    addPopover(bpmnElementId, bpmnVisualization);
+    addOverlay(bpmnElementId, bpmnVisualization);
   }
 }
 
-function addPopover(activityId: string, bpmnVisualization: BpmnVisualization) {
-  const activity = bpmnVisualization.bpmnElementsRegistry.getElementsByIds(activityId)[0];
-  registerBpmnElement(activity);
+function addPopover(bpmnElementId: string, bpmnVisualization: BpmnVisualization) {
+  const bpmnElement = bpmnVisualization.bpmnElementsRegistry.getElementsByIds(bpmnElementId)[0];
+  registerBpmnElement(bpmnElement);
 
-  const tippyInstance = tippy(activity.htmlElement, {
+  const tippyInstance = tippy(bpmnElement.htmlElement, {
     theme: 'light',
     placement: 'bottom',
     appendTo: bpmnVisualization.graph.container,
@@ -135,8 +135,8 @@ function addPopover(activityId: string, bpmnVisualization: BpmnVisualization) {
   }
 }
 
-function addOverlay(activityId: string, bpmnVisualization: BpmnVisualization) {
-  bpmnVisualization.bpmnElementsRegistry.addOverlays(activityId, {
+function addOverlay(bpmnElementId: string, bpmnVisualization: BpmnVisualization) {
+  bpmnVisualization.bpmnElementsRegistry.addOverlays(bpmnElementId, {
     position: 'top-right',
     label: '?',
     style: {

--- a/src/case-monitoring.ts
+++ b/src/case-monitoring.ts
@@ -34,6 +34,7 @@ function reduceVisibilityOfAlreadyExecutedElements(bpmnVisualization: BpmnVisual
 }
 
 function restoreVisibilityOfAlreadyExecutedElements(bpmnVisualization: BpmnVisualization) {
+  // TODO why adding pending?  the CSS class was not added in reduceVisibilityOfAlreadyExecutedElements
   bpmnVisualization.bpmnElementsRegistry.removeCssClasses(Array.from([...caseMonitoringData.executedShapes, ...caseMonitoringData.pendingShapes, ...caseMonitoringData.visitedEdges]), 'state-already-executed');
 }
 

--- a/src/case-monitoring.ts
+++ b/src/case-monitoring.ts
@@ -103,36 +103,32 @@ function addPopover(bpmnElementId: string, bpmnVisualization: BpmnVisualization)
     onShown(instance: Instance): void {
       if (currentView === 'main') {
         instance.setContent(getRecommendationInfoAsHtml(instance.reference));
+        // eslint-disable-next-line no-warning-comments -- cannot be managed now
+        // TODO avoid hard coding or manage this in the same class that generate 'getRecommendationInfoAsHtml'
+        const contactClientBtn = document.querySelector('#Contact-Client');
+        console.info('tippy on show: contactClientBtn', contactClientBtn);
+        if (contactClientBtn) {
+          console.info('tippy on show: registering event listener on click');
+          contactClientBtn.addEventListener('click', () => {
+            showContactClientAction();
+          });
+        }
+
+        const allocateResourceBtn = document.querySelector('#Allocate-Resource');
+        console.info('tippy on show: allocateResourceBtn', allocateResourceBtn);
+        if (allocateResourceBtn) {
+          console.info('tippy on show: registering event listener on click');
+          allocateResourceBtn.addEventListener('click', () => {
+            showResourceAllocationAction();
+          });
+        }
       } else {
         instance.setContent(getWarningInfoAsHtml());
-        // Instance.setContent(getWarningInfoAsHtml(instance.reference));
       }
     },
   } as Partial<Props>);
 
   tippyInstances.push(tippyInstance);
-
-  // eslint-disable-next-line no-warning-comments -- cannot be managed now
-  // TODO make it work
-  // get references to the buttons in the Tippy popover
-  if (currentView === 'main') {
-    tippyInstance.popper.addEventListener('mouseover', (event: MouseEvent) => {
-      const target = event.target as HTMLElement;
-      const allocateResourceBtn = target.querySelector('#Allocate-Resource');
-      const contactClientBtn = target.querySelector('#Contact-Client');
-      if (allocateResourceBtn) {
-        allocateResourceBtn.addEventListener('click', () => {
-          showResourceAllocationAction();
-        });
-      }
-
-      if (contactClientBtn) {
-        contactClientBtn.addEventListener('click', () => {
-          showContactClientAction();
-        });
-      }
-    });
-  }
 }
 
 function addOverlay(bpmnElementId: string, bpmnVisualization: BpmnVisualization) {
@@ -262,5 +258,6 @@ function showResourceAllocationAction() {
 
 function showContactClientAction() {
   // TO BE IMPLEMENTED
+  window.alert('Clicked on showContactClientAction');
 }
 

--- a/src/case-monitoring.ts
+++ b/src/case-monitoring.ts
@@ -110,7 +110,8 @@ function addPopover(activityId: string, bpmnVisualization: BpmnVisualization) {
       if (currentView === 'main') {
         instance.setContent(getRecommendationInfoAsHtml(instance.reference));
       } else {
-        instance.setContent(getWarningInfoAsHtml(instance.reference));
+        instance.setContent(getWarningInfoAsHtml());
+        // instance.setContent(getWarningInfoAsHtml(instance.reference));
       }
     },
   } as Partial<Props>);
@@ -207,7 +208,8 @@ function getRecommendationInfoAsHtml(htmlElement: ReferenceElement) {
   return popoverContent;
 }
 
-function getWarningInfoAsHtml(htmlElement: ReferenceElement) {
+function getWarningInfoAsHtml() {
+// function getWarningInfoAsHtml(htmlElement: ReferenceElement) {
   const popoverContent = `
         <div class="popover-container">
           <h4>Resource not available</h4>
@@ -273,11 +275,11 @@ function showResourceAllocationAction() {
       The listener is NOT WORKING
     */
     popoverInstance.popper.addEventListener('mouseover', (event: MouseEvent) => {
-      console.log('hello there');
       const target = event.target as HTMLElement;
-      if (target.nodeName === 'TD') {
-        const selectedRow = target.parentElement as HTMLTableRowElement;
-      }
+      console.info('listener mouseover, target', target);
+      // if (target.nodeName === 'TD') {
+      //   const selectedRow = target.parentElement as HTMLTableRowElement;
+      // }
     });
   } else {
     console.log('instance not found');

--- a/src/case-monitoring.ts
+++ b/src/case-monitoring.ts
@@ -105,6 +105,7 @@ function addPopover(bpmnElementId: string, bpmnVisualization: BpmnVisualization)
         instance.setContent(getRecommendationInfoAsHtml(instance.reference));
         // eslint-disable-next-line no-warning-comments -- cannot be managed now
         // TODO avoid hard coding or manage this in the same class that generate 'getRecommendationInfoAsHtml'
+        // eslint-disable-next-line no-warning-comments -- cannot be managed now
         // TODO only register the event listener once, or destroy it onHide
         const contactClientBtn = document.querySelector('#Contact-Client');
         console.info('tippy on show: contactClientBtn', contactClientBtn);
@@ -258,7 +259,9 @@ function showResourceAllocationAction() {
 }
 
 function showContactClientAction() {
-  // TO BE IMPLEMENTED
+  // eslint-disable-next-line no-warning-comments -- cannot be managed now
+  // TODO implement
+  // eslint-disable-next-line no-alert -- will be remove with the final implementation
   window.alert('Clicked on showContactClientAction');
 }
 

--- a/src/case-monitoring.ts
+++ b/src/case-monitoring.ts
@@ -139,28 +139,6 @@ function addPopover(activityId: string, bpmnVisualization: BpmnVisualization) {
       }
     });
   }
-
-  // eslint-disable-next-line no-warning-comments -- cannot be managed now
-  // TODO use CSS classes to handle hover on table within the tippy instance
-  // Add mouseover and mouseout event listeners to the table rows
-  tippyInstance.popper.addEventListener('mouseover', (event: Event) => {
-    const target = event.target as HTMLElement;
-    if (target.nodeName === 'TD') {
-      const selectedRow = target.parentElement as HTMLTableRowElement;
-      selectedRow.style.backgroundColor = 'lightgray';
-      selectedRow.style.color = 'black';
-    }
-  });
-
-  tippyInstance.popper.addEventListener('mouseout', (event: Event) => {
-    const target = event.target as HTMLElement;
-    if (target.nodeName === 'TD') {
-      const selectedRow = target.parentElement as HTMLTableRowElement;
-      selectedRow.style.backgroundColor = '';
-      selectedRow.style.color = '';
-    }
-  });
-  // END of -- TO DO use CSS classes to handle hover on table within the tippy instance
 }
 
 function addOverlay(activityId: string, bpmnVisualization: BpmnVisualization) {
@@ -227,21 +205,21 @@ function getWarningInfoAsHtml() {
               </tr>
             </thead>
             <tbody>
-              <tr>
+              <tr class="popover-row">
                 <td>Resource 1</td>
                 <td>Yes</td>
                 <td class="popover-action">
                     <button>Assign</button>
                 </td>
               </tr>
-              <tr>
+              <tr class="popover-row">
                 <td>Resource 2</td>
                 <td>Yes</td>
                 <td class="popover-action">
                     <button>Assign</button>
                 </td>
               </tr>
-              <tr>
+              <tr class="popover-row">
                 <td>Resource 3</td>
                 <td>Yes</td>
                 <td class="popover-action">

--- a/src/case-monitoring.ts
+++ b/src/case-monitoring.ts
@@ -105,6 +105,7 @@ function addPopover(bpmnElementId: string, bpmnVisualization: BpmnVisualization)
         instance.setContent(getRecommendationInfoAsHtml(instance.reference));
         // eslint-disable-next-line no-warning-comments -- cannot be managed now
         // TODO avoid hard coding or manage this in the same class that generate 'getRecommendationInfoAsHtml'
+        // TODO only register the event listener once, or destroy it onHide
         const contactClientBtn = document.querySelector('#Contact-Client');
         console.info('tippy on show: contactClientBtn', contactClientBtn);
         if (contactClientBtn) {

--- a/src/case-monitoring.ts
+++ b/src/case-monitoring.ts
@@ -140,6 +140,8 @@ function addPopover(activityId: string, bpmnVisualization: BpmnVisualization) {
     });
   }
 
+
+  // TODO use CSS classes to handle hover on table within the tippy instance
   // Add mouseover and mouseout event listeners to the table rows
   tippyInstance.popper.addEventListener('mouseover', (event: Event) => {
     const target = event.target as HTMLElement;
@@ -158,6 +160,7 @@ function addPopover(activityId: string, bpmnVisualization: BpmnVisualization) {
       selectedRow.style.color = '';
     }
   });
+  // END of -- TO DO use CSS classes to handle hover on table within the tippy instance
 }
 
 function addOverlay(activityId: string, bpmnVisualization: BpmnVisualization) {
@@ -187,7 +190,7 @@ function getRecommendationInfoAsHtml(htmlElement: ReferenceElement) {
   const bpmnSemantic = registeredBpmnElements.get(htmlElement);
   const activityRecommendationData = getActivityRecommendationData(bpmnSemantic?.name ?? '');
   for (const recommendation of activityRecommendationData) {
-    // Replace space with hypen (-) to be passed as the button id
+    // Replace space with hyphen (-) to be passed as the button id
     const buttonId = recommendation.title.replace(/\s+/g, '-');
     popoverContent += `
             <tr class="popover-row">
@@ -210,7 +213,7 @@ function getRecommendationInfoAsHtml(htmlElement: ReferenceElement) {
 
 function getWarningInfoAsHtml() {
 // function getWarningInfoAsHtml(htmlElement: ReferenceElement) {
-  const popoverContent = `
+  return `
         <div class="popover-container">
           <h4>Resource not available</h4>
           <p>The resource "pierre" is not available to execute this task.</p>
@@ -249,7 +252,6 @@ function getWarningInfoAsHtml() {
           </table>
         </div>
     `;
-  return popoverContent;
 }
 
 function showResourceAllocationAction() {

--- a/src/case-monitoring.ts
+++ b/src/case-monitoring.ts
@@ -236,7 +236,7 @@ function showResourceAllocationAction() {
   const enabledShapeId = caseMonitoringData.enabledShapes.values().next().value as string;
   const enabledShape = secondaryBpmnVisualization.bpmnElementsRegistry.getElementsByIds(enabledShapeId)[0];
   const popoverInstance = tippyInstances.find(instance => {
-    if (instance.reference === enabledShape.htmlElement) {
+    if (instance.reference === enabledShape?.htmlElement) {
       return instance;
     }
 

--- a/src/case-monitoring.ts
+++ b/src/case-monitoring.ts
@@ -9,13 +9,7 @@ const tippyInstances: Instance[] = [];
 
 const registeredBpmnElements = new Map<Element, BpmnSemantic>();
 
-let caseMonitoringData: CaseMonitoringData = {
-  executedShapes: new Set<string>(),
-  enabledShapes: new Set<string>(),
-  pendingShapes: new Set<string>(),
-  runningActivities: new Set<string>(),
-  visitedEdges: new Set<string>(),
-};
+let caseMonitoringData: CaseMonitoringData;
 
 export function showCaseMonitoringData(processId: string, bpmnVisualization: BpmnVisualization) {
   caseMonitoringData = getCaseMonitoringData(processId, bpmnVisualization);
@@ -36,28 +30,26 @@ export function hideCaseMonitoringData(processId: string, bpmnVisualization: Bpm
 }
 
 function reduceVisibilityOfAlreadyExecutedElements(bpmnVisualization: BpmnVisualization) {
-  const executedElements = new Set<string>([...caseMonitoringData.executedShapes, ...caseMonitoringData.visitedEdges]);
-  bpmnVisualization.bpmnElementsRegistry.addCssClasses(Array.from(executedElements), 'state-already-executed');
+  bpmnVisualization.bpmnElementsRegistry.addCssClasses(Array.from([...caseMonitoringData.executedShapes, ...caseMonitoringData.visitedEdges]), 'state-already-executed');
 }
 
 function restoreVisibilityOfAlreadyExecutedElements(bpmnVisualization: BpmnVisualization) {
-  const executedElements = new Set<string>([...caseMonitoringData.executedShapes, ...caseMonitoringData.pendingShapes, ...caseMonitoringData.visitedEdges]);
-  bpmnVisualization.bpmnElementsRegistry.removeCssClasses(Array.from(executedElements), 'state-already-executed');
+  bpmnVisualization.bpmnElementsRegistry.removeCssClasses(Array.from([...caseMonitoringData.executedShapes, ...caseMonitoringData.pendingShapes, ...caseMonitoringData.visitedEdges]), 'state-already-executed');
 }
 
 // eslint-disable-next-line no-warning-comments -- cannot be managed now
 // TODO: rename CSS class
 function highlightRunningElements(bpmnVisualization: BpmnVisualization) {
-  const runningActivities = caseMonitoringData.runningActivities;
-  bpmnVisualization.bpmnElementsRegistry.addCssClasses(Array.from(runningActivities), 'state-running-late');
+  const runningActivities = Array.from(caseMonitoringData.runningActivities);
+  bpmnVisualization.bpmnElementsRegistry.addCssClasses(runningActivities, 'state-running-late');
   if (currentView === 'main') {
     addInfoOnRunningElements(runningActivities, bpmnVisualization);
   }
 }
 
 export function highlightEnabledElements(bpmnVisualization: BpmnVisualization) {
-  const enabledActivities = caseMonitoringData.enabledShapes;
-  bpmnVisualization.bpmnElementsRegistry.addCssClasses(Array.from(enabledActivities), 'state-enabled');
+  const enabledActivities = Array.from(caseMonitoringData.enabledShapes);
+  bpmnVisualization.bpmnElementsRegistry.addCssClasses(enabledActivities, 'state-enabled');
   if (currentView === 'secondary') {
     addInfoOnEnabledElements(enabledActivities, bpmnVisualization);
   }
@@ -78,14 +70,14 @@ function resetRunningElements(bpmnVisualization: BpmnVisualization) {
   tippyInstances.length = 0;
 }
 
-function addInfoOnRunningElements(runningActivities: Set<string>, bpmnVisualization: BpmnVisualization) {
+function addInfoOnRunningElements(runningActivities: string[], bpmnVisualization: BpmnVisualization) {
   for (const activityId of runningActivities) {
     addPopover(activityId, bpmnVisualization);
     addOverlay(activityId, bpmnVisualization);
   }
 }
 
-function addInfoOnEnabledElements(enabledActivities: Set<string>, bpmnVisualization: BpmnVisualization) {
+function addInfoOnEnabledElements(enabledActivities: string[], bpmnVisualization: BpmnVisualization) {
   for (const activityId of enabledActivities) {
     addPopover(activityId, bpmnVisualization);
     addOverlay(activityId, bpmnVisualization);

--- a/src/case-monitoring.ts
+++ b/src/case-monitoring.ts
@@ -34,6 +34,7 @@ function reduceVisibilityOfAlreadyExecutedElements(bpmnVisualization: BpmnVisual
 }
 
 function restoreVisibilityOfAlreadyExecutedElements(bpmnVisualization: BpmnVisualization) {
+  // eslint-disable-next-line no-warning-comments -- question to answer by Nour
   // TODO why adding pending?  the CSS class was not added in reduceVisibilityOfAlreadyExecutedElements
   bpmnVisualization.bpmnElementsRegistry.removeCssClasses(Array.from([...caseMonitoringData.executedShapes, ...caseMonitoringData.pendingShapes, ...caseMonitoringData.visitedEdges]), 'state-already-executed');
 }

--- a/src/diagram.ts
+++ b/src/diagram.ts
@@ -6,7 +6,6 @@ import {removeSectionInBreadcrumb, addSectionInBreadcrumb} from './breadcrumb.js
 const sharedFitOptions = {type: FitType.Center, margin: 20};
 
 export const sharedLoadOptions: LoadOptions = {fit: sharedFitOptions};
-
 export let secondaryBpmnDiagramIsAlreadyLoad = false;
 export let currentView = 'main';
 

--- a/src/diagram.ts
+++ b/src/diagram.ts
@@ -6,7 +6,11 @@ import {removeSectionInBreadcrumb, addSectionInBreadcrumb} from './breadcrumb.js
 const sharedFitOptions = {type: FitType.Center, margin: 20};
 
 export const sharedLoadOptions: LoadOptions = {fit: sharedFitOptions};
+// eslint-disable-next-line no-warning-comments -- cannot be managed now
+// TODO do not leak internal state
+// eslint-disable-next-line import/no-mutable-exports -- will be refactored later
 export let secondaryBpmnDiagramIsAlreadyLoad = false;
+// eslint-disable-next-line import/no-mutable-exports -- will be refactored later
 export let currentView = 'main';
 
 // Secondary BPMN Container

--- a/src/diagram.ts
+++ b/src/diagram.ts
@@ -7,7 +7,7 @@ const sharedFitOptions = {type: FitType.Center, margin: 20};
 
 export const sharedLoadOptions: LoadOptions = {fit: sharedFitOptions};
 
-let secondaryBpmnDiagramIsAlreadyLoad = false;
+export let secondaryBpmnDiagramIsAlreadyLoad = false;
 export let currentView = 'main';
 
 // Secondary BPMN Container

--- a/src/diagram.ts
+++ b/src/diagram.ts
@@ -8,10 +8,10 @@ const sharedFitOptions = {type: FitType.Center, margin: 20};
 export const sharedLoadOptions: LoadOptions = {fit: sharedFitOptions};
 
 let secondaryBpmnDiagramIsAlreadyLoad = false;
-let currentView = 'main';
+export let currentView = 'main';
 
 // Secondary BPMN Container
-const secondaryBpmnVisualization = new BpmnVisualization({container: 'secondary-bpmn-container'});
+export const secondaryBpmnVisualization = new BpmnVisualization({container: 'secondary-bpmn-container'});
 
 export function displayBpmnDiagram(tabIndex: string): void {
   if (currentView === tabIndex) {

--- a/src/process-monitoring.ts
+++ b/src/process-monitoring.ts
@@ -69,13 +69,13 @@ function getHappyPathClasses(index: number, elementId: string) {
 
   let classToAdd;
   let styleInnerHtml;
-  if (isActivity(elementId)) {
+  if (isActivity(elementId, 'main')) {
     styleInnerHtml = `.animate-${elementId} > rect { animation-delay: ${delay}s; animation-duration: ${animationDuration}s; }`;
     classToAdd = 'pulse-happy';
-  } else if (isEvent(elementId)) {
+  } else if (isEvent(elementId, 'main')) {
     styleInnerHtml = `.animate-${elementId} > ellipse { animation-delay: ${delay}s; animation-duration: ${animationDuration}s; }`;
     classToAdd = 'pulse-happy';
-  } else if (isGateway(elementId)) {
+  } else if (isGateway(elementId, 'main')) {
     styleInnerHtml = `.animate-${elementId} > path { animation-delay: ${delay}s; animation-duration: ${animationDuration}s; }`;
     classToAdd = 'gateway-happy';
   } else {

--- a/src/process-monitoring.ts
+++ b/src/process-monitoring.ts
@@ -69,13 +69,13 @@ function getHappyPathClasses(index: number, elementId: string) {
 
   let classToAdd;
   let styleInnerHtml;
-  if (isActivity(elementId, 'main')) {
+  if (isActivity(elementId)) {
     styleInnerHtml = `.animate-${elementId} > rect { animation-delay: ${delay}s; animation-duration: ${animationDuration}s; }`;
     classToAdd = 'pulse-happy';
-  } else if (isEvent(elementId, 'main')) {
+  } else if (isEvent(elementId)) {
     styleInnerHtml = `.animate-${elementId} > ellipse { animation-delay: ${delay}s; animation-duration: ${animationDuration}s; }`;
     classToAdd = 'pulse-happy';
-  } else if (isGateway(elementId, 'main')) {
+  } else if (isGateway(elementId)) {
     styleInnerHtml = `.animate-${elementId} > path { animation-delay: ${delay}s; animation-duration: ${animationDuration}s; }`;
     classToAdd = 'gateway-happy';
   } else {

--- a/src/style.css
+++ b/src/style.css
@@ -134,12 +134,8 @@ header {
 :root {
   --color-default-fill: white;
   --color-path-executed: #aea3a3;
-  --color-path-predicted-late: orange;
-  --color-state-predicted-late: orange;
-  --color-path-predicted-on-time: #67d567;
-  --color-state-predicted-on-time: #a7f0a7;
-  --color-state-running: #9c9cef;
-  --stroke-path-predicted: 0.18rem;
+  --color-state-running-late: orange;
+  --color-state-enabled: #d3d3d3;
 }
 
   /* parallel gateway icon */
@@ -176,35 +172,17 @@ header {
   filter: blur(1px);
 }
 
-/* ================================================================================================================== */
-/* INFO */
-/* ================================================================================================================== */
-
-/* only the surrounding path of gateway, otherwise the diamond is darker (double fill) */
-.bpmn-type-gateway.state-running > path:nth-child(1),
-.bpmn-type-event.state-running > ellipse,
-/* envelope of the message event */
-.bpmn-event-def-message.state-running > rect {
-  fill: var(--color-state-running);
-}
-
-/*apply shadow on hover*/
-.bpmn-type-event.state-running:hover,
-.bpmn-type-gateway.state-running:hover {
-  filter: drop-shadow(0 0 0.5em rgba(0, 0, 0));
-}
-
 
 /* ================================================================================================================== */
-/* PREDICTED LATE */
+/* RUNNING LATE */
 /* ================================================================================================================== */
 
 /*for filter drop-shadow: https://css-tricks.com/adding-shadows-to-svg-icons-with-css-and-svg-filters/*/
 /*for pulse animation: https://reactgo.com/css-pulse-animation/*/
 
 /* task */
-.bpmn-type-activity.state-predicted-late > rect {
-  fill: var(--color-state-predicted-late);
+.bpmn-type-activity.state-running-late > rect {
+  fill: var(--color-state-running-late);
   animation: pulse-animation 0.8s infinite alternate;
 }
 
@@ -219,40 +197,36 @@ header {
   }
 }
 
-  /* message flow start marker */
-.bpmn-message-flow.path-predicted-late > ellipse,
-  /* sequence flow arrow */
-.bpmn-sequence-flow.path-predicted-late > path:nth-child(3) {
-  fill: var(--color-path-predicted-late);
+/* ================================================================================================================== */
+/* ENABLED */
+/* ================================================================================================================== */
+
+/* task */
+.bpmn-type-activity.state-enabled> rect {
+  fill: var(--color-state-enabled);
+}
+  
+/* parallel gateway icon */
+.bpmn-parallel-gateway.state-enabled > path:nth-child(2),
+/* message flow arrow */
+.bpmn-message-flow.state-enabled > path:nth-child(4){
+  fill: var(--color-state-enabled);
 }
 
+  /* message flow start marker */
+.bpmn-message-flow.state-enabled > ellipse,
   /* sequence/message flow line and arrow (end marker) */
-.bpmn-type-flow.path-predicted-late > path,
-  /* message flow start marker */
-.bpmn-message-flow.path-predicted-late > ellipse,
-.bpmn-type-gateway.path-predicted-late > path:nth-child(1),
-.bpmn-type-task.path-predicted-late > rect,
-.bpmn-type-event.path-predicted-late > ellipse {
-  stroke: var(--color-path-predicted-late);
-  stroke-width: var(--stroke-path-predicted);
-}
-
-.bpmn-type-gateway.path-predicted-late > path:nth-child(1),
-.bpmn-event-based-gateway.path-predicted-late > ellipse,
-.bpmn-event-based-gateway.path-predicted-late > path:nth-child(7),
-.bpmn-event-def-message.path-predicted-late > rect,
-.bpmn-event-def-message.path-predicted-late > path,
-.bpmn-event-def-timer.path-predicted-late > path,
-.bpmn-type-event.path-predicted-late > ellipse {
-  stroke: var(--color-path-predicted-late);
-  fill: var(--color-default-fill);
-}
-
-/* labels (the selector applies to all div, not the only one that contains text, but this is ok.
-Use important to override the color set inline in the style attribute of the label div */
-.bpmn-label.path-predicted-late > g div {
-  color: var(--color-path-predicted-late) !important;
-  font-weight: bold;
+.bpmn-type-flow.state-enabled > path,
+  /* task */
+.bpmn-type-task.state-enabled > rect,
+  /* parallel gateway stroke and icon */
+.bpmn-parallel-gateway.state-enabled > path,
+  /* message event icon */
+.bpmn-event-def-message.state-enabled > rect,
+.bpmn-event-def-message.state-enabled > path,
+  /* event stroke */
+.bpmn-type-event.state-enabled > ellipse {
+  fill: var(--color-state-enabled);
 }
 
 

--- a/src/style.css
+++ b/src/style.css
@@ -205,7 +205,7 @@ header {
 .bpmn-type-activity.state-enabled> rect {
   fill: var(--color-state-enabled);
 }
-  
+
 /* parallel gateway icon */
 .bpmn-parallel-gateway.state-enabled > path:nth-child(2),
 /* message flow arrow */
@@ -232,6 +232,7 @@ header {
 
 /* ================================================================================================================== */
 /* RECOMMENDATION POPOVER */
+/* More generally case-monitoring */
 /* ================================================================================================================== */
 
 /*padding: 10px;
@@ -247,6 +248,11 @@ th.popover-title {
   font-weight: bold;
   font-size: 16px;
   padding: 10px;
+}
+
+tr.popover-row:hover {
+  background-color: lightgray;
+  color: black;
 }
 
 td.popover-key {
@@ -281,7 +287,3 @@ button {
 button:hover {
   background-color: #3e8e41;
 }
-
-/*.popover-row:nth-child(even) {*/
-/*  background-color: #f2f2f2;*/
-/*}*/

--- a/src/use-case-management.ts
+++ b/src/use-case-management.ts
@@ -22,17 +22,16 @@ export function configureUseCaseSelectors(bpmnVisualization: BpmnVisualization) 
     showCaseMonitoringData('main', bpmnVisualization);
   }, () => {
     hideCaseMonitoringData('main', bpmnVisualization);
-    if(secondaryBpmnDiagramIsAlreadyLoad){
+    if (secondaryBpmnDiagramIsAlreadyLoad) {
       hideCaseMonitoringData('secondary', secondaryBpmnVisualization);
     }
-    
   });
 
   const initialUseCase = new UseCaseSelector('radio-reset-all', () => {
     processVisualizer.showManuallyTriggeredProcess();
     subProcessNavigator.enable();
   }, () => {
-    subProcessNavigator.disable(); 
+    subProcessNavigator.disable();
   });
   initialUseCase.select();
 }

--- a/src/use-case-management.ts
+++ b/src/use-case-management.ts
@@ -1,7 +1,7 @@
 import {type BpmnVisualization} from 'bpmn-visualization';
 import {hideCaseMonitoringData, showCaseMonitoringData} from './case-monitoring.js';
 import {hideHappyPath, showHappyPath} from './process-monitoring.js';
-import {ProcessVisualizer, SubProcessNavigator} from './diagram.js';
+import {ProcessVisualizer, secondaryBpmnDiagramIsAlreadyLoad, secondaryBpmnVisualization, SubProcessNavigator} from './diagram.js';
 
 export function configureUseCaseSelectors(bpmnVisualization: BpmnVisualization) {
   const processVisualizer = new ProcessVisualizer(bpmnVisualization);
@@ -21,14 +21,18 @@ export function configureUseCaseSelectors(bpmnVisualization: BpmnVisualization) 
     processVisualizer.hideManuallyTriggeredProcess();
     showCaseMonitoringData('main', bpmnVisualization);
   }, () => {
-    hideCaseMonitoringData(bpmnVisualization);
+    hideCaseMonitoringData('main', bpmnVisualization);
+    if(secondaryBpmnDiagramIsAlreadyLoad){
+      hideCaseMonitoringData('secondary', secondaryBpmnVisualization);
+    }
+    
   });
 
   const initialUseCase = new UseCaseSelector('radio-reset-all', () => {
     processVisualizer.showManuallyTriggeredProcess();
     subProcessNavigator.enable();
   }, () => {
-    subProcessNavigator.disable();
+    subProcessNavigator.disable(); 
   });
   initialUseCase.select();
 }

--- a/src/use-case-management.ts
+++ b/src/use-case-management.ts
@@ -19,7 +19,7 @@ export function configureUseCaseSelectors(bpmnVisualization: BpmnVisualization) 
   // eslint-disable-next-line no-new
   new UseCaseSelector('radio-case-monitoring', () => {
     processVisualizer.hideManuallyTriggeredProcess();
-    showCaseMonitoringData(bpmnVisualization);
+    showCaseMonitoringData('main', bpmnVisualization);
   }, () => {
     hideCaseMonitoringData(bpmnVisualization);
   });

--- a/src/utils/bpmn-elements.ts
+++ b/src/utils/bpmn-elements.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {type BpmnVisualization, ShapeUtil} from 'bpmn-visualization';
+import {type BpmnSemantic, type BpmnVisualization, ShapeBpmnElementKind, ShapeUtil} from 'bpmn-visualization';
 
 /**
  * Provides workarounds for {@link https://github.com/process-analytics/bpmn-visualization-js/issues/2453}.
@@ -22,9 +22,24 @@ import {type BpmnVisualization, ShapeUtil} from 'bpmn-visualization';
 export class BpmnElementsSearcher {
   constructor(private readonly bpmnVisualization: BpmnVisualization) {}
 
-  getElementByName(name: string): void {}
+  getElementIdByName(name: string): string | undefined {
+    return this.getElementByName(name)?.id;
+  }
 
-  getElementIdByName(name: string): string | undefined {}
+  // Only work for shape for now
+  // not optimize, do a full lookup at each call
+  private getElementByName(name: string): BpmnSemantic | undefined {
+    console.info('Search element for name', name);
+    const kinds = Object.values(ShapeBpmnElementKind);
+    // Split query by kind to avoid returning a big chunk of data
+    for (const kind of kinds) {
+      console.info('lookup kind', kind);
+      const elements = this.bpmnVisualization.bpmnElementsRegistry.getElementsByKinds(kind);
+      if (elements.length > 0 && elements[0].bpmnSemantic.name === 'name') {
+        return elements[0].bpmnSemantic;
+      }
+    }
+  }
 }
 
 export class BpmnElementsIdentifier {

--- a/src/utils/bpmn-elements.ts
+++ b/src/utils/bpmn-elements.ts
@@ -1,0 +1,54 @@
+/*
+Copyright 2023 Bonitasoft S.A.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import {type BpmnVisualization, ShapeUtil} from 'bpmn-visualization';
+
+/**
+ * Provides workarounds for {@link https://github.com/process-analytics/bpmn-visualization-js/issues/2453}.
+ */
+export class BpmnElementsSearcher {
+  constructor(private readonly bpmnVisualization: BpmnVisualization) {}
+
+  getElementByName(name: string): void {}
+
+  getElementIdByName(name: string): string | undefined {}
+}
+
+export class BpmnElementsIdentifier {
+  constructor(private readonly bpmnVisualization: BpmnVisualization) {}
+
+  isActivity(elementId: string): boolean {
+    return this.isInCategory(ShapeUtil.isActivity, elementId);
+  }
+
+  isGateway(elementId: string): boolean {
+    return this.isInCategory(ShapeUtil.isGateway, elementId);
+  }
+
+  isEvent(elementId: string): boolean {
+    return this.isInCategory(ShapeUtil.isEvent, elementId);
+  }
+
+  private isInCategory(categorizeFunction: (value: string) => boolean, elementId: string): boolean {
+    const elements = this.bpmnVisualization.bpmnElementsRegistry.getElementsByIds(elementId);
+    if (elements.length > 0) {
+      const kind = elements[0].bpmnSemantic.kind;
+      return categorizeFunction(kind);
+    }
+
+    return false;
+  }
+}

--- a/src/utils/bpmn-elements.ts
+++ b/src/utils/bpmn-elements.ts
@@ -35,7 +35,7 @@ export class BpmnElementsSearcher {
     for (const kind of kinds) {
       console.info('lookup kind', kind);
       const elements = this.bpmnVisualization.bpmnElementsRegistry.getElementsByKinds(kind);
-      if (elements.length > 0 && elements[0].bpmnSemantic.name === 'name') {
+      if (elements.length > 0 && elements[0].bpmnSemantic.name === name ) {
         return elements[0].bpmnSemantic;
       }
     }

--- a/src/utils/bpmn-elements.ts
+++ b/src/utils/bpmn-elements.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {type BpmnSemantic, type BpmnVisualization, ShapeBpmnElementKind, ShapeUtil} from 'bpmn-visualization';
+import {type BpmnSemantic, type BpmnVisualization, ShapeBpmnElementKind} from 'bpmn-visualization';
 
 /**
  * Provides workarounds for {@link https://github.com/process-analytics/bpmn-visualization-js/issues/2453}.
@@ -46,31 +46,5 @@ export class BpmnElementsSearcher {
     }
 
     return undefined;
-  }
-}
-
-export class BpmnElementsIdentifier {
-  constructor(private readonly bpmnVisualization: BpmnVisualization) {}
-
-  isActivity(elementId: string): boolean {
-    return this.isInCategory(ShapeUtil.isActivity, elementId);
-  }
-
-  isGateway(elementId: string): boolean {
-    return this.isInCategory(ShapeUtil.isGateway, elementId);
-  }
-
-  isEvent(elementId: string): boolean {
-    return this.isInCategory(ShapeUtil.isEvent, elementId);
-  }
-
-  private isInCategory(categorizeFunction: (value: string) => boolean, elementId: string): boolean {
-    const elements = this.bpmnVisualization.bpmnElementsRegistry.getElementsByIds(elementId);
-    if (elements.length > 0) {
-      const kind = elements[0].bpmnSemantic.kind;
-      return categorizeFunction(kind);
-    }
-
-    return false;
   }
 }

--- a/src/utils/bpmn-elements.ts
+++ b/src/utils/bpmn-elements.ts
@@ -39,6 +39,8 @@ export class BpmnElementsSearcher {
         return elements[0].bpmnSemantic;
       }
     }
+
+    return undefined;
   }
 }
 

--- a/src/utils/bpmn-elements.ts
+++ b/src/utils/bpmn-elements.ts
@@ -29,14 +29,19 @@ export class BpmnElementsSearcher {
   // Only work for shape for now
   // not optimize, do a full lookup at each call
   private getElementByName(name: string): BpmnSemantic | undefined {
-    console.info('Search element for name', name);
     const kinds = Object.values(ShapeBpmnElementKind);
     // Split query by kind to avoid returning a big chunk of data
     for (const kind of kinds) {
-      console.info('lookup kind', kind);
-      const elements = this.bpmnVisualization.bpmnElementsRegistry.getElementsByKinds(kind);
-      if (elements.length > 0 && elements[0].bpmnSemantic.name === name ) {
-        return elements[0].bpmnSemantic;
+      const bpmnSemantics = this.bpmnVisualization.bpmnElementsRegistry.getElementsByKinds(kind)
+        .map(elt => elt.bpmnSemantic)
+        .filter(Boolean);
+
+      // May have been implemented with: bpmnSemantics.filter(bpmnSemantic => bpmnSemantic.name === name)[0];
+      // Here, we stop the search right after we find a matching name
+      for (const bpmnSemantic of bpmnSemantics) {
+        if (bpmnSemantic.name === name) {
+          return bpmnSemantic;
+        }
       }
     }
 

--- a/src/utils/bpmn-elements.ts
+++ b/src/utils/bpmn-elements.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {type BpmnSemantic, type BpmnVisualization, ShapeBpmnElementKind} from 'bpmn-visualization';
+import {type BpmnSemantic, type BpmnVisualization, ShapeBpmnElementKind, ShapeUtil} from 'bpmn-visualization';
 
 /**
  * Provides workarounds for {@link https://github.com/process-analytics/bpmn-visualization-js/issues/2453}.
@@ -46,5 +46,31 @@ export class BpmnElementsSearcher {
     }
 
     return undefined;
+  }
+}
+
+export class BpmnElementsIdentifier {
+  constructor(private readonly bpmnVisualization: BpmnVisualization) {}
+
+  isActivity(elementId: string): boolean {
+    return this.isInCategory(ShapeUtil.isActivity, elementId);
+  }
+
+  isGateway(elementId: string): boolean {
+    return this.isInCategory(ShapeUtil.isGateway, elementId);
+  }
+
+  isEvent(elementId: string): boolean {
+    return this.isInCategory(ShapeUtil.isEvent, elementId);
+  }
+
+  private isInCategory(categorizeFunction: (value: string) => boolean, elementId: string): boolean {
+    const elements = this.bpmnVisualization.bpmnElementsRegistry.getElementsByIds(elementId);
+    if (elements.length > 0) {
+      const kind = elements[0].bpmnSemantic.kind;
+      return categorizeFunction(kind);
+    }
+
+    return false;
   }
 }

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -16,6 +16,11 @@ limitations under the License.
 
 import type {BpmnVisualization, EdgeBpmnSemantic, ShapeBpmnSemantic} from 'bpmn-visualization';
 
+/**
+ * Experimental implementation for
+ * - {@link https://github.com/process-analytics/bpmn-visualization-js/issues/930}
+ * - {@link https://github.com/process-analytics/bpmn-visualization-js/issues/2402}
+ */
 export class PathResolver {
   constructor(private readonly bpmnVisualization: BpmnVisualization) {}
 

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -1,0 +1,48 @@
+/*
+Copyright 2023 Bonitasoft S.A.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+import type {BpmnVisualization, EdgeBpmnSemantic, ShapeBpmnSemantic} from 'bpmn-visualization';
+
+export class PathResolver {
+  constructor(private readonly bpmnVisualization: BpmnVisualization) {}
+
+  getVisitedEdges(shapeIds: string[]): string[] {
+    const edgeIds = new Set<string>();
+    for (const shape of shapeIds) {
+      const shapeElt = this.bpmnVisualization.bpmnElementsRegistry.getElementsByIds(shape)[0];
+      const bpmnSemantic = shapeElt.bpmnSemantic as ShapeBpmnSemantic;
+      const incomingEdges = bpmnSemantic.incomingIds;
+      const outgoingEdges = bpmnSemantic.outgoingIds;
+      for (const edgeId of incomingEdges) {
+        const edgeElement = this.bpmnVisualization.bpmnElementsRegistry.getElementsByIds(edgeId)[0];
+        const sourceRef = (edgeElement.bpmnSemantic as EdgeBpmnSemantic).sourceRefId;
+        if (shapeIds.includes(sourceRef)) {
+          edgeIds.add(edgeId);
+        }
+      }
+
+      for (const edgeId of outgoingEdges) {
+        const edgeElement = this.bpmnVisualization.bpmnElementsRegistry.getElementsByIds(edgeId)[0];
+        const targetRef = (edgeElement.bpmnSemantic as EdgeBpmnSemantic).targetRefId;
+        if (shapeIds.includes(targetRef)) {
+          edgeIds.add(edgeId);
+        }
+      }
+    }
+
+    return Array.from(edgeIds);
+  }
+}


### PR DESCRIPTION
When clicking on the "Allocate more resource" button, the sub-process diagram is displayed.
- It's running task is highlighted and the path leading to it is modified as well. This task proposed a popover which opens on hover.
- In the future, the style of some elements of the diagram will be modified when hovering on the row of the popover.
When clicking on the "Contact-Client" button, a window alert is displayed. In the future, it will display the 2nd process of the diagram and it will let interact with it.


### Implementation notes

This PR introduces refactoring to better encapsulate the logic.
In particular, it provides classes that may be reused outside this demo and served as starting point for experimental features
- BpmnElementsSearcher https://github.com/process-analytics/bpmn-visualization-js/issues/2453
- PathResolver https://github.com/process-analytics/bpmn-visualization-js/issues/930 https://github.com/process-analytics/bpmn-visualization-js/issues/2402

The case monitoring data are fully managed by dedicated classes both for the main process and the sub-process. 
Other parts of the code are still leaking the use cases at several places. This will be refactored later to limit the size of this PR.


### Screenshots
**Note**: we see that several event listeners are registered on the button (as the window alert opens several times)

https://user-images.githubusercontent.com/27200110/225014409-464ec6de-4ecb-465c-ada5-affbd60eeac2.mp4


