### PR TITLE
fix: do not capitalize the text

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     </ul>
 </header>
 <div class="divider m-0"></div>
-<section class="container text-capitalize">
+<section class="container">
     <div class="columns col-11 col-mx-auto mt-2">
         <div class="col-12 my-2">
             <div id="main-bpmn-container" class="bpmn-container"></div>


### PR DESCRIPTION
A CSS class was present by mistake and capitalized the text of the elements of the diagram and the text in the popover.

### Screenshots

process | before | after
----- | ----- | -----
main | ![01_before_main_process_02_cropped](https://user-images.githubusercontent.com/27200110/225030055-5f0d14aa-53d5-4d76-8864-59a95944504e.png) | ![02_after_main_process_02_cropped](https://user-images.githubusercontent.com/27200110/225030066-2ec980e8-b627-4427-ba98-f4bc686862a0.png)
subprocess | ![01_before_sub-process_02_cropped](https://user-images.githubusercontent.com/27200110/225030063-ab5d8e47-4808-4167-8c3e-0bd3066aa9f6.png) | ![02_after_sub-process_02_cropped](https://user-images.githubusercontent.com/27200110/225030071-d024d93a-71de-4d83-8de4-e4f3b69bb69e.png)
