### PR TITLE
refactor: do lazy initializations and improve view management

### DIFF
--- a/src/breadcrumb.ts
+++ b/src/breadcrumb.ts
@@ -1,8 +1,8 @@
-import {displayBpmnDiagram} from './diagram.js';
+import {displayView} from './diagram.js';
 
 export const configureBreadcrumb = (): void => {
   document.querySelector('#breadcrumb-main-diagram')!.addEventListener('click', () => {
-    displayBpmnDiagram('main');
+    displayView('main');
   });
 };
 

--- a/src/case-monitoring-data.ts
+++ b/src/case-monitoring-data.ts
@@ -109,7 +109,7 @@ class SubProcessCaseMonitoringDataProvider extends AbstractCaseMonitoringDataPro
   }
 }
 
-export function getCaseMonitoringData(processId: string, bpmnVisualization: BpmnVisualization): CaseMonitoringData {
+export function fetchCaseMonitoringData(processId: string, bpmnVisualization: BpmnVisualization): CaseMonitoringData {
   const caseMonitoringDataProvider = processId === 'main' ? new MainProcessCaseMonitoringDataProvider(bpmnVisualization) : new SubProcessCaseMonitoringDataProvider(bpmnVisualization);
 
   const executedShapes = caseMonitoringDataProvider.getExecutedShapes();

--- a/src/case-monitoring.ts
+++ b/src/case-monitoring.ts
@@ -6,7 +6,7 @@ import {type CaseMonitoringData, fetchCaseMonitoringData} from './case-monitorin
 import {displayView, subProcessBpmnVisualization, subProcessViewName} from './diagram.js';
 
 abstract class AbstractCaseMonitoring {
-  protected caseMonitoringData: CaseMonitoringData | undefined = undefined;
+  protected caseMonitoringData: CaseMonitoringData | undefined;
   protected tippySupport: AbstractTippySupport;
 
   protected constructor(protected readonly bpmnVisualization: BpmnVisualization, private readonly processId: string) {

--- a/src/case-monitoring.ts
+++ b/src/case-monitoring.ts
@@ -2,18 +2,15 @@ import tippy, {type Instance, type Props, type ReferenceElement} from 'tippy.js'
 import 'tippy.js/dist/tippy.css';
 import type {BpmnElement, BpmnSemantic, BpmnVisualization} from 'bpmn-visualization';
 import {getActivityRecommendationData} from './recommendation-data.js';
-import {type CaseMonitoringData, getCaseMonitoringData} from './case-monitoring-data.js';
-import {displayBpmnDiagram, subProcessBpmnVisualization, subProcessViewName} from './diagram.js';
+import {type CaseMonitoringData, fetchCaseMonitoringData} from './case-monitoring-data.js';
+import {displayView, subProcessBpmnVisualization, subProcessViewName} from './diagram.js';
 
 abstract class AbstractCaseMonitoring {
-  protected caseMonitoringData: CaseMonitoringData;
+  protected caseMonitoringData: CaseMonitoringData | undefined = undefined;
   protected tippySupport: AbstractTippySupport;
 
-  protected constructor(protected readonly bpmnVisualization: BpmnVisualization, processId: string) {
+  protected constructor(protected readonly bpmnVisualization: BpmnVisualization, private readonly processId: string) {
     console.info('init CaseMonitoring, processId: %s / bpmn-container: %s', processId, bpmnVisualization.graph.container.id);
-    // eslint-disable-next-line no-warning-comments -- cannot be managed now
-    // TODO initialization. Is it the right place?
-    this.caseMonitoringData = getCaseMonitoringData(processId, this.bpmnVisualization);
     this.tippySupport = this.createTippySupportInstance(bpmnVisualization);
     console.info('DONE init CaseMonitoring, processId', processId);
   }
@@ -33,12 +30,20 @@ abstract class AbstractCaseMonitoring {
     console.info('end hideData / bpmn-container: %s', this.bpmnVisualization.graph.container.id);
   }
 
+  protected getCaseMonitoringData() {
+    if (!this.caseMonitoringData) {
+      this.caseMonitoringData = fetchCaseMonitoringData(this.processId, this.bpmnVisualization);
+    }
+
+    return this.caseMonitoringData;
+  }
+
   protected highlightRunningElements(): void {
-    this.bpmnVisualization.bpmnElementsRegistry.addCssClasses(this.caseMonitoringData.runningActivities, 'state-running-late');
+    this.bpmnVisualization.bpmnElementsRegistry.addCssClasses(this.getCaseMonitoringData().runningActivities, 'state-running-late');
   }
 
   protected highlightEnabledElements(): void {
-    this.bpmnVisualization.bpmnElementsRegistry.addCssClasses(this.caseMonitoringData.enabledShapes, 'state-enabled');
+    this.bpmnVisualization.bpmnElementsRegistry.addCssClasses(this.getCaseMonitoringData().enabledShapes, 'state-enabled');
   }
 
   protected addOverlay(bpmnElementId: string) {
@@ -56,17 +61,17 @@ abstract class AbstractCaseMonitoring {
   protected abstract createTippySupportInstance(bpmnVisualization: BpmnVisualization): AbstractTippySupport;
 
   private reduceVisibilityOfAlreadyExecutedElements(): void {
-    this.bpmnVisualization.bpmnElementsRegistry.addCssClasses([...this.caseMonitoringData.executedShapes, ...this.caseMonitoringData.visitedEdges], 'state-already-executed');
+    this.bpmnVisualization.bpmnElementsRegistry.addCssClasses([...this.getCaseMonitoringData().executedShapes, ...this.getCaseMonitoringData().visitedEdges], 'state-already-executed');
   }
 
   private restoreVisibilityOfAlreadyExecutedElements() {
     // eslint-disable-next-line no-warning-comments -- question to answer by Nour
     // TODO why adding pending?  the CSS class was not added in reduceVisibilityOfAlreadyExecutedElements
-    this.bpmnVisualization.bpmnElementsRegistry.removeCssClasses([...this.caseMonitoringData.executedShapes, ...this.caseMonitoringData.pendingShapes, ...this.caseMonitoringData.visitedEdges], 'state-already-executed');
+    this.bpmnVisualization.bpmnElementsRegistry.removeCssClasses([...this.getCaseMonitoringData().executedShapes, ...this.getCaseMonitoringData().pendingShapes, ...this.getCaseMonitoringData().visitedEdges], 'state-already-executed');
   }
 
   private resetRunningElements() {
-    const elements = this.caseMonitoringData.runningActivities;
+    const elements = this.getCaseMonitoringData().runningActivities;
     this.bpmnVisualization.bpmnElementsRegistry.removeCssClasses(elements, 'state-running-late');
     for (const elementId of elements) {
       this.bpmnVisualization.bpmnElementsRegistry.removeAllOverlays(elementId);
@@ -83,7 +88,7 @@ export class MainProcessCaseMonitoring extends AbstractCaseMonitoring {
 
   protected highlightRunningElements(): void {
     super.highlightRunningElements();
-    this.addInfoOnRunningElements(this.caseMonitoringData.runningActivities);
+    this.addInfoOnRunningElements(this.getCaseMonitoringData().runningActivities);
   }
 
   protected createTippySupportInstance(bpmnVisualization: BpmnVisualization): AbstractTippySupport {
@@ -105,7 +110,7 @@ class SubProcessCaseMonitoring extends AbstractCaseMonitoring {
 
   protected highlightEnabledElements(): void {
     super.highlightEnabledElements();
-    this.addInfoOnEnabledElements(this.caseMonitoringData.enabledShapes);
+    this.addInfoOnEnabledElements(this.getCaseMonitoringData().enabledShapes);
   }
 
   protected createTippySupportInstance(bpmnVisualization: BpmnVisualization): AbstractTippySupport {
@@ -309,7 +314,7 @@ export function hideSubCaseMonitoringData(bpmnVisualization: BpmnVisualization) 
 // TODO trigger by main, but the logic should be only for subprocess
 function showResourceAllocationAction() {
   // This should be managed by SubProcessNavigator
-  displayBpmnDiagram(subProcessViewName);
+  displayView(subProcessViewName);
   showSubProcessMonitoringData(subProcessBpmnVisualization);
   /*
     TO FIX: currently the code assumes that there's only one enabled shape

--- a/src/diagram.ts
+++ b/src/diagram.ts
@@ -121,7 +121,7 @@ const doSubProcessNavigation = () => {
 };
 
 export class SubProcessNavigator {
-  private subProcessHtmlElement: HTMLElement | undefined = undefined;
+  private subProcessHtmlElement: HTMLElement | undefined;
 
   constructor(private readonly bpmnVisualization: BpmnVisualization) {}
 

--- a/src/diagram.ts
+++ b/src/diagram.ts
@@ -9,7 +9,7 @@ const sharedFitOptions = {type: FitType.Center, margin: 20};
 
 export const sharedLoadOptions: LoadOptions = {fit: sharedFitOptions};
 
-let currentView: View | undefined = undefined;
+let currentView: View | undefined;
 
 // eslint-disable-next-line no-warning-comments -- cannot be managed now
 // TODO change the view/processId value. secondary is for the subprocess!! This impacts HTML elements

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,17 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {BpmnVisualization} from 'bpmn-visualization';
-// eslint-disable-next-line n/file-extension-in-import -- Vite syntax
-import collapsedDiagram from './diagrams/EC-purchase-orders-collapsed.bpmn?raw';
 import {configureBreadcrumb} from './breadcrumb.js';
-import {sharedLoadOptions} from './diagram.js';
 import {configureUseCaseSelectors} from './use-case-management.js';
 
-const bpmnVisualization = new BpmnVisualization({
-  container: 'main-bpmn-container',
-});
-bpmnVisualization.load(collapsedDiagram, sharedLoadOptions);
-
 configureBreadcrumb();
-configureUseCaseSelectors(bpmnVisualization);
+configureUseCaseSelectors();

--- a/src/use-case-management.ts
+++ b/src/use-case-management.ts
@@ -1,9 +1,19 @@
-import {type BpmnVisualization} from 'bpmn-visualization';
 import {hideSubCaseMonitoringData, MainProcessCaseMonitoring} from './case-monitoring.js';
+import {
+  mainBpmnVisualization as bpmnVisualization,
+  ProcessVisualizer,
+  isSubProcessBpmnDiagramIsAlreadyLoad,
+  subProcessBpmnVisualization,
+  SubProcessNavigator,
+  displayView,
+} from './diagram.js';
 import {hideHappyPath, showHappyPath} from './process-monitoring.js';
-import {ProcessVisualizer, subProcessBpmnDiagramIsAlreadyLoad, subProcessBpmnVisualization, SubProcessNavigator} from './diagram.js';
 
-export function configureUseCaseSelectors(bpmnVisualization: BpmnVisualization) {
+const displayMainView = () => {
+  displayView('main');
+};
+
+export function configureUseCaseSelectors() {
   const processVisualizer = new ProcessVisualizer(bpmnVisualization);
   const subProcessNavigator = new SubProcessNavigator(bpmnVisualization);
 
@@ -26,7 +36,7 @@ export function configureUseCaseSelectors(bpmnVisualization: BpmnVisualization) 
     mainProcessCaseMonitoring.hideData();
     // eslint-disable-next-line no-warning-comments -- cannot be managed now
     // TODO move the logic into case-monitoring or ideally in the subprocess navigator which should manage the data hide
-    if (subProcessBpmnDiagramIsAlreadyLoad) {
+    if (isSubProcessBpmnDiagramIsAlreadyLoad()) {
       hideSubCaseMonitoringData(subProcessBpmnVisualization);
     }
   });
@@ -46,6 +56,7 @@ class UseCaseSelector {
     document.querySelector(`#${id}`)?.addEventListener('click', () => {
       if (currentUseCase !== this) {
         currentUseCase?.unselect();
+        displayMainView();
         selectCallback();
         // eslint-disable-next-line @typescript-eslint/no-this-alias,unicorn/no-this-assignment -- need to store this in a variable
         currentUseCase = this;


### PR DESCRIPTION
Treat the initialization and loading of the main diagram in the same way as we do for the sub-process diagram.
This involves lazily loading the initialization of the various parts that previously assumed that the main diagram was loaded and thus, that searches always returned elements

The other refactoring of the views mainly concerns the improvement of the naming of functions and variables.


### Side effects (for good and for bad 😈) 

Previously, there was a bug in the case monitoring use case after we displayed the data on the sub-process.
If in the sub-process view, we decided to change the use case (click on a radio button) and we go back to the main view, the diagram was broken. Most shapes strokes and some labels disappeared.
Changing the use case make the stroke reappear but some labels were missing.

**TODO video @assynour can you add it here please**

With the refactoring, this bug has gone.
However, the monitoring data are not remove from the sub-process view. This will be handled later as part of a refactoring to better manage and split responsibilities.


https://user-images.githubusercontent.com/27200110/225257307-1f8d192c-ef32-4f52-98ec-6d4f75bb7255.mp4
