### PR TITLE
feat(supplier): hide supplier data

### DIFF
--- a/src/case-monitoring/main-process.ts
+++ b/src/case-monitoring/main-process.ts
@@ -73,7 +73,7 @@ class MainProcessTippySupport extends AbstractTippySupport {
   // Hack from https://stackoverflow.com/questions/56079864/how-to-remove-an-event-listener-within-a-class
   private readonly contactClientBtnListener = () => {
     console.info('called contactClientBtnListener private method');
-    showContactSupplierAction(this.bpmnVisualization).then(() => {
+    showContactSupplierAction().then(() => {
       console.log('Contact client action complete!');
     })
       .catch(error => {

--- a/src/case-monitoring/main-process.ts
+++ b/src/case-monitoring/main-process.ts
@@ -19,7 +19,7 @@ import 'tippy.js/dist/tippy.css';
 import type {BpmnVisualization} from 'bpmn-visualization';
 import {getActivityRecommendationData} from '../recommendation-data.js';
 import {AbstractCaseMonitoring, AbstractTippySupport} from './abstract.js';
-import {showContactSupplierAction} from './supplier.js';
+import {hideSupplierContactData, showContactSupplierAction} from './supplier.js';
 import {hideSubCaseMonitoringData, showResourceAllocationAction} from './sub-process.js';
 
 export class MainProcessCaseMonitoring extends AbstractCaseMonitoring {
@@ -31,6 +31,7 @@ export class MainProcessCaseMonitoring extends AbstractCaseMonitoring {
     super.hideData();
     // eslint-disable-next-line no-warning-comments -- cannot be managed now
     // TODO move the logic out of this class. Ideally in the subprocess navigator which should manage the data hide
+    hideSupplierContactData();
     hideSubCaseMonitoringData();
   }
 

--- a/src/case-monitoring/supplier.ts
+++ b/src/case-monitoring/supplier.ts
@@ -20,6 +20,13 @@ class SupplierProcessCaseMonitoring extends AbstractCaseMonitoring {
   protected createTippySupportInstance(bpmnVisualization: BpmnVisualization): AbstractTippySupport {
     return new SupplierProcessTippySupport(bpmnVisualization);
   }
+
+  hideData(): void {
+    console.info('start hideData / contact supplier pool');
+    //Only popovers for now
+    this.tippySupport.removeAllPopovers();
+    console.info('end hideData / contact supplier pool');
+  }
 }
 
 class SupplierProcessTippySupport extends AbstractTippySupport {
@@ -213,6 +220,6 @@ export function hideSupplierContactData() {
   if (SupplierContact.supplierContactInstances.length > 0) {
     SupplierContact.stopAllCases();
   }
-
+  
   supplierMonitoring.hideData();
 }

--- a/src/case-monitoring/supplier.ts
+++ b/src/case-monitoring/supplier.ts
@@ -136,8 +136,7 @@ class SupplierContact {
   // required to stope the execution of the async function startInstance
   private readonly abortController: AbortController = new AbortController();
 
-  constructor(readonly bpmnVisualization: BpmnVisualization, readonly supplierMonitoring: SupplierProcessCaseMonitoring) {
-  }
+  constructor(readonly bpmnVisualization: BpmnVisualization, readonly supplierMonitoring: SupplierProcessCaseMonitoring) {}
 
   // eslint-disable-next-line no-warning-comments -- cannot be managed now
   // TODO this could should really be async!!!

--- a/src/case-monitoring/supplier.ts
+++ b/src/case-monitoring/supplier.ts
@@ -1,6 +1,6 @@
 import {type BpmnVisualization} from 'bpmn-visualization/*';
 import {type ReferenceElement} from 'tippy.js';
-import {mainBpmnVisualization, ProcessVisualizer} from '../diagram.js';
+import {mainBpmnVisualization as bpmnVisualization, ProcessVisualizer} from '../diagram.js';
 import {BpmnElementsSearcher} from '../utils/bpmn-elements.js';
 import {AbstractCaseMonitoring, AbstractTippySupport} from './abstract.js';
 
@@ -175,11 +175,11 @@ class SupplierContact {
   }
 }
 
-const supplierMonitoring = new SupplierProcessCaseMonitoring(mainBpmnVisualization);
+const supplierMonitoring = new SupplierProcessCaseMonitoring(bpmnVisualization);
 
 // eslint-disable-next-line no-warning-comments -- cannot be managed now
 // TODO trigger by main process
-export async function showContactSupplierAction(bpmnVisualization: BpmnVisualization): Promise<void> {
+export async function showContactSupplierAction(): Promise<void> {
   // eslint-disable-next-line no-warning-comments -- cannot be managed now
   // TODO implement
 


### PR DESCRIPTION
- Make sure to abort the execution of the async supplier contact case before hiding data
- Execution is not aborted when going from the **case monitoring** to the **subprocess view** (for resource allocation)

![hide-supplier-data](https://user-images.githubusercontent.com/67027776/226356342-b2c4827b-fcfc-4244-af90-d56923e8214c.gif)
