### PR TITLE
refactor: rename the function that hides sub-process data

### DIFF
--- a/src/case-monitoring/main-process.ts
+++ b/src/case-monitoring/main-process.ts
@@ -20,7 +20,7 @@ import type {BpmnVisualization} from 'bpmn-visualization';
 import {getActivityRecommendationData} from '../recommendation-data.js';
 import {AbstractCaseMonitoring, AbstractTippySupport} from './abstract.js';
 import {hideSupplierContactData, showContactSupplierAction} from './supplier.js';
-import {hideSubCaseMonitoringData, showResourceAllocationAction} from './sub-process.js';
+import {hideSubProcessCaseMonitoringData, showResourceAllocationAction} from './sub-process.js';
 
 export class MainProcessCaseMonitoring extends AbstractCaseMonitoring {
   constructor(bpmnVisualization: BpmnVisualization) {
@@ -32,7 +32,7 @@ export class MainProcessCaseMonitoring extends AbstractCaseMonitoring {
     // eslint-disable-next-line no-warning-comments -- cannot be managed now
     // TODO move the logic out of this class. Ideally in the subprocess navigator which should manage the data hide
     hideSupplierContactData();
-    hideSubCaseMonitoringData();
+    hideSubProcessCaseMonitoringData();
   }
 
   protected highlightRunningElements(): void {

--- a/src/case-monitoring/sub-process.ts
+++ b/src/case-monitoring/sub-process.ts
@@ -170,7 +170,7 @@ function getWarningInfoAsHtml() {
 
 const subProcessCaseMonitoring = new SubProcessCaseMonitoring(subProcessBpmnVisualization);
 
-export function hideSubCaseMonitoringData() {
+export function hideSubProcessCaseMonitoringData() {
   // Currently mandatory, if the diagram is not loaded error, this seems to be a bug in bpmn-visualization
   // calling getElementsByIds when the diagram is not loaded generates an error. It should respond without errors.
   // seen with bpmn-visualization@0.32.0
@@ -183,7 +183,7 @@ export function hideSubCaseMonitoringData() {
   //     getCaseMonitoringData abstract.ts:32
   //     restoreVisibilityOfAlreadyExecutedElements abstract.ts:67
   //     hideData abstract.ts:25
-  //     hideSubCaseMonitoringData case-monitoring.ts:262
+  //     hideSubProcessCaseMonitoringData case-monitoring.ts:262
   //     configureUseCaseSelectors use-case-management.ts:36
   //     unselect use-case-management.ts:69
   //     UseCaseSelector use-case-management.ts:53


### PR DESCRIPTION
Use a more convenient name.