### PR TITLE
refactor: inject "tippy support" collaborator in `CaseMonitoring`

### DIFF
--- a/src/case-monitoring/abstract.ts
+++ b/src/case-monitoring/abstract.ts
@@ -6,9 +6,9 @@ export abstract class AbstractCaseMonitoring {
   protected caseMonitoringData: CaseMonitoringData | undefined;
   protected tippySupport: AbstractTippySupport;
 
-  protected constructor(protected readonly bpmnVisualization: BpmnVisualization, private readonly processId: string) {
+  protected constructor(protected readonly bpmnVisualization: BpmnVisualization, private readonly processId: string, tippySupport: AbstractTippySupport) {
     console.info('init CaseMonitoring, processId: %s / bpmn-container: %s', processId, bpmnVisualization.graph.container.id);
-    this.tippySupport = this.createTippySupportInstance(bpmnVisualization);
+    this.tippySupport = tippySupport;
     console.info('DONE init CaseMonitoring, processId', processId);
   }
 
@@ -49,8 +49,6 @@ export abstract class AbstractCaseMonitoring {
       },
     });
   }
-
-  protected abstract createTippySupportInstance(bpmnVisualization: BpmnVisualization): AbstractTippySupport;
 
   private reduceVisibilityOfAlreadyExecutedElements(): void {
     this.bpmnVisualization.bpmnElementsRegistry.addCssClasses([...this.getCaseMonitoringData().executedShapes, ...this.getCaseMonitoringData().visitedEdges], 'state-already-executed');

--- a/src/case-monitoring/abstract.ts
+++ b/src/case-monitoring/abstract.ts
@@ -4,12 +4,9 @@ import {type CaseMonitoringData, fetchCaseMonitoringData} from '../case-monitori
 
 export abstract class AbstractCaseMonitoring {
   protected caseMonitoringData: CaseMonitoringData | undefined;
-  protected tippySupport: AbstractTippySupport;
 
-  protected constructor(protected readonly bpmnVisualization: BpmnVisualization, private readonly processId: string, tippySupport: AbstractTippySupport) {
-    console.info('init CaseMonitoring, processId: %s / bpmn-container: %s', processId, bpmnVisualization.graph.container.id);
-    this.tippySupport = tippySupport;
-    console.info('DONE init CaseMonitoring, processId', processId);
+  protected constructor(protected readonly bpmnVisualization: BpmnVisualization, private readonly processId: string, protected tippySupport: AbstractTippySupport) {
+    console.info('Initialized AbstractCaseMonitoring, processId: %s / bpmn-container: %s', processId, bpmnVisualization.graph.container.id);
   }
 
   showData(): void {

--- a/src/case-monitoring/main-process.ts
+++ b/src/case-monitoring/main-process.ts
@@ -22,9 +22,13 @@ import {AbstractCaseMonitoring, AbstractTippySupport} from './abstract.js';
 import {hideSupplierContactData, showContactSupplierAction} from './supplier.js';
 import {hideSubProcessCaseMonitoringData, showResourceAllocationAction} from './sub-process.js';
 
-export class MainProcessCaseMonitoring extends AbstractCaseMonitoring {
-  constructor(bpmnVisualization: BpmnVisualization) {
-    super(bpmnVisualization, 'main');
+export function newMainProcessCaseMonitoring(bpmnVisualization: BpmnVisualization) {
+  return new MainProcessCaseMonitoring(bpmnVisualization, new MainProcessTippySupport(bpmnVisualization));
+}
+
+class MainProcessCaseMonitoring extends AbstractCaseMonitoring {
+  constructor(bpmnVisualization: BpmnVisualization, tippySupport: AbstractTippySupport) {
+    super(bpmnVisualization, 'main', tippySupport);
   }
 
   hideData(): void {
@@ -38,10 +42,6 @@ export class MainProcessCaseMonitoring extends AbstractCaseMonitoring {
   protected highlightRunningElements(): void {
     this.bpmnVisualization.bpmnElementsRegistry.addCssClasses(this.getCaseMonitoringData().runningShapes, 'state-running-late');
     this.addInfoOnRunningElements(this.getCaseMonitoringData().runningShapes);
-  }
-
-  protected createTippySupportInstance(bpmnVisualization: BpmnVisualization): AbstractTippySupport {
-    return new MainProcessTippySupport(bpmnVisualization);
   }
 
   // Duplicated with SubProcessCaseMonitoring.addInfoOnRunningElements

--- a/src/case-monitoring/main-process.ts
+++ b/src/case-monitoring/main-process.ts
@@ -27,7 +27,7 @@ export function newMainProcessCaseMonitoring(bpmnVisualization: BpmnVisualizatio
 }
 
 class MainProcessCaseMonitoring extends AbstractCaseMonitoring {
-  constructor(bpmnVisualization: BpmnVisualization, tippySupport: AbstractTippySupport) {
+  constructor(bpmnVisualization: BpmnVisualization, tippySupport: MainProcessTippySupport) {
     super(bpmnVisualization, 'main', tippySupport);
   }
 

--- a/src/case-monitoring/sub-process.ts
+++ b/src/case-monitoring/sub-process.ts
@@ -20,7 +20,7 @@ import {displayView, isSubProcessBpmnDiagramIsAlreadyLoad, subProcessBpmnVisuali
 import {AbstractCaseMonitoring, AbstractTippySupport} from './abstract.js';
 
 class SubProcessCaseMonitoring extends AbstractCaseMonitoring {
-  constructor(bpmnVisualization: BpmnVisualization, tippySupport: AbstractTippySupport) {
+  constructor(bpmnVisualization: BpmnVisualization, tippySupport: SubProcessTippySupport) {
     super(bpmnVisualization, subProcessViewName, tippySupport);
   }
 

--- a/src/case-monitoring/sub-process.ts
+++ b/src/case-monitoring/sub-process.ts
@@ -20,17 +20,13 @@ import {displayView, isSubProcessBpmnDiagramIsAlreadyLoad, subProcessBpmnVisuali
 import {AbstractCaseMonitoring, AbstractTippySupport} from './abstract.js';
 
 class SubProcessCaseMonitoring extends AbstractCaseMonitoring {
-  constructor(bpmnVisualization: BpmnVisualization) {
-    super(bpmnVisualization, subProcessViewName);
+  constructor(bpmnVisualization: BpmnVisualization, tippySupport: AbstractTippySupport) {
+    super(bpmnVisualization, subProcessViewName, tippySupport);
   }
 
   protected highlightRunningElements(): void {
     this.bpmnVisualization.bpmnElementsRegistry.addCssClasses(this.getCaseMonitoringData().runningShapes, 'state-enabled');
     this.addInfoOnRunningElements(this.getCaseMonitoringData().runningShapes);
-  }
-
-  protected createTippySupportInstance(bpmnVisualization: BpmnVisualization): AbstractTippySupport {
-    return new SubProcessTippySupport(bpmnVisualization);
   }
 
   // Duplicated with MainProcessCaseMonitoring.addInfoOnRunningElements
@@ -168,7 +164,7 @@ function getWarningInfoAsHtml() {
     `;
 }
 
-const subProcessCaseMonitoring = new SubProcessCaseMonitoring(subProcessBpmnVisualization);
+const subProcessCaseMonitoring = new SubProcessCaseMonitoring(subProcessBpmnVisualization, new SubProcessTippySupport(subProcessBpmnVisualization));
 
 export function hideSubProcessCaseMonitoringData() {
   // Currently mandatory, if the diagram is not loaded error, this seems to be a bug in bpmn-visualization

--- a/src/case-monitoring/supplier.ts
+++ b/src/case-monitoring/supplier.ts
@@ -5,12 +5,12 @@ import {BpmnElementsSearcher} from '../utils/bpmn-elements.js';
 import {AbstractCaseMonitoring, AbstractTippySupport} from './abstract.js';
 
 class SupplierProcessCaseMonitoring extends AbstractCaseMonitoring {
-  constructor(bpmnVisualization: BpmnVisualization, tippySupport: AbstractTippySupport) {
+  constructor(bpmnVisualization: BpmnVisualization, tippySupport: SupplierProcessTippySupport) {
     super(bpmnVisualization, 'main', tippySupport);
   }
 
-  getTippySupportInstance() {
-    return this.tippySupport;
+  getTippySupportInstance(): SupplierProcessTippySupport {
+    return this.tippySupport as SupplierProcessTippySupport;
   }
 
   addInfoOnChatGptActivity(bpmnElementId: string) {
@@ -207,7 +207,7 @@ class SupplierContact {
   }
 
   protected addInfo(activityId: string, prompt: string, answer: string) {
-    const tippySupportInstance = this.supplierMonitoring.getTippySupportInstance() as SupplierProcessTippySupport;
+    const tippySupportInstance = this.supplierMonitoring.getTippySupportInstance();
     if (tippySupportInstance !== undefined) {
       tippySupportInstance.setUserQuestion(prompt);
       tippySupportInstance.setChatGptAnswer(answer);

--- a/src/case-monitoring/supplier.ts
+++ b/src/case-monitoring/supplier.ts
@@ -5,8 +5,8 @@ import {BpmnElementsSearcher} from '../utils/bpmn-elements.js';
 import {AbstractCaseMonitoring, AbstractTippySupport} from './abstract.js';
 
 class SupplierProcessCaseMonitoring extends AbstractCaseMonitoring {
-  constructor(bpmnVisualization: BpmnVisualization) {
-    super(bpmnVisualization, 'main');
+  constructor(bpmnVisualization: BpmnVisualization, tippySupport: AbstractTippySupport) {
+    super(bpmnVisualization, 'main', tippySupport);
   }
 
   getTippySupportInstance() {
@@ -64,10 +64,6 @@ class SupplierProcessCaseMonitoring extends AbstractCaseMonitoring {
         },
       },
     );
-  }
-
-  protected createTippySupportInstance(bpmnVisualization: BpmnVisualization): AbstractTippySupport {
-    return new SupplierProcessTippySupport(bpmnVisualization);
   }
 }
 
@@ -227,7 +223,7 @@ class SupplierContact {
   }
 }
 
-const supplierContact = new SupplierContact(bpmnVisualization, new SupplierProcessCaseMonitoring(bpmnVisualization));
+const supplierContact = new SupplierContact(bpmnVisualization, new SupplierProcessCaseMonitoring(bpmnVisualization, new SupplierProcessTippySupport(bpmnVisualization)));
 const processVisualizer = new ProcessVisualizer(bpmnVisualization);
 
 // eslint-disable-next-line no-warning-comments -- cannot be managed now

--- a/src/use-case-management.ts
+++ b/src/use-case-management.ts
@@ -1,4 +1,4 @@
-import {MainProcessCaseMonitoring} from './case-monitoring/main-process.js';
+import {newMainProcessCaseMonitoring} from './case-monitoring/main-process.js';
 import {
   mainBpmnVisualization as bpmnVisualization,
   ProcessVisualizer,
@@ -17,7 +17,7 @@ export function configureUseCaseSelectors(selectedUseCase: string) {
   const processVisualizer = new ProcessVisualizer(bpmnVisualization);
   const subProcessNavigator = new SubProcessNavigator(bpmnVisualization);
 
-  const mainProcessCaseMonitoring = new MainProcessCaseMonitoring(bpmnVisualization);
+  const mainProcessCaseMonitoring = newMainProcessCaseMonitoring(bpmnVisualization);
 
   const useCases = new Map<string, UseCaseSelector>();
   useCases.set('process-monitoring', new UseCaseSelector('radio-process-monitoring', () => {


### PR DESCRIPTION
Prefer to pass the "tippy support" collaborator for a better separation of concerns instead of making CaseMonitoring aware of how it is instantiated.