### PR TITLE
feat(supplier): process executor manages popovers

### DIFF
--- a/src/case-monitoring/supplier-utils.ts
+++ b/src/case-monitoring/supplier-utils.ts
@@ -37,9 +37,6 @@ const executionSteps = new Map<string, ExecutionStep>([
     action() {
       console.info('#### action on Activity_04d6t36');
     },
-    // Manage manually or with resume?
-    // nextExecutionStep: 'Activity_1oxewnq',
-    // duration: 3_000
   }],
   // Activity_1oxewnq review email. Stop here, next step chosen by user
   ['Activity_1oxewnq', {id: 'Activity_1oxewnq', incomingEdgeId: 'Flow_092it75',
@@ -76,7 +73,7 @@ export const getExecutionStepAfterReviewEmailChoice = (decision: ReviewEmailDeci
 
 type ExecutionStep = {
   id: string;
-  /** In milliseconds. */
+  /** In milliseconds, override the default duration set for the shape or the edge. */
   duration?: number;
   incomingEdgeId?: string;
   nextExecutionStep?: string | ExecutionStep;

--- a/src/case-monitoring/supplier-utils.ts
+++ b/src/case-monitoring/supplier-utils.ts
@@ -87,7 +87,7 @@ export class ProcessExecutor {
 
   private readonly executionCounts = new Map<string, number>();
 
-  constructor(bpmnVisualization: BpmnVisualization, private readonly emailRetrievalOperationsCallBack: (id: string) => void, private readonly endCaseCallBack: () => void) {
+  constructor(bpmnVisualization: BpmnVisualization, private readonly endCaseCallBack: () => void, private readonly emailRetrievalOperationsCallBack: (id: string) => void) {
     this.pathHighlighter = new PathHighlighter(bpmnVisualization);
   }
 
@@ -144,6 +144,10 @@ export class ProcessExecutor {
       Promise.resolve()
         .then(() => executionStep.action?.())
         .then(() => {
+          // This is a temp implementation, this should be done with executionStep.action?.()
+          // but this requires to be able to dynamically set the action function which is not possible for now
+          // instead, we hard code the action behavior here as we only have 2 different actions to manage.
+
           this.emailRetrievalOperationsCallBack(executionStep.id);
         })
         // ignored - to be improved see https://typescript-eslint.io/rules/no-floating-promises/

--- a/src/case-monitoring/supplier-utils.ts
+++ b/src/case-monitoring/supplier-utils.ts
@@ -85,6 +85,8 @@ type ExecutionStep = {
   isLastStep?: boolean;
 };
 
+const processExecutorWaitTimeBeforeCallingEndCaseCallback = 1500;
+
 export class ProcessExecutor {
   private readonly pathHighlighter: PathHighlighter;
 
@@ -167,16 +169,17 @@ export class ProcessExecutor {
         });
       logProcessExecution('DONE call execution of next step', executionStep.nextExecutionStep);
     } else if (executionStep.isLastStep) {
-      logProcessExecution('detected as last step, so clearing everything');
-      this.clear();
-      logProcessExecution('clear done');
-
       logProcessExecution('registering endCaseCallBack call');
       new Promise<void>(resolve => {
         setTimeout(() => {
           resolve();
-        }, 2000);
+        }, processExecutorWaitTimeBeforeCallingEndCaseCallback);
       })
+        .then(() => {
+          logProcessExecution('detected as last step, so clearing everything');
+          this.clear();
+          logProcessExecution('clear done');
+        })
         .then(() => {
           logProcessExecution('calling endCaseCallBack');
         })

--- a/src/case-monitoring/supplier-utils.ts
+++ b/src/case-monitoring/supplier-utils.ts
@@ -35,15 +35,18 @@ const executionSteps = new Map<string, ExecutionStep>([
   // Activity_04d6t36 chatGPT activity
   ['Activity_04d6t36', {id: 'Activity_04d6t36', incomingEdgeId: 'Flow_06y94ol',
     action() {
-      console.info('#### call popover');
-      // Resume when done
+      console.info('#### action on Activity_04d6t36');
     },
     // Manage manually or with resume?
     // nextExecutionStep: 'Activity_1oxewnq',
     // duration: 3_000
   }],
   // Activity_1oxewnq review email. Stop here, next step chosen by user
-  ['Activity_1oxewnq', {id: 'Activity_1oxewnq', incomingEdgeId: 'Flow_092it75'}],
+  ['Activity_1oxewnq', {id: 'Activity_1oxewnq', incomingEdgeId: 'Flow_092it75',
+    action() {
+      console.info('#### action on Activity_1oxewnq');
+    },
+  }],
 
   // After email review
   // Event_13tn0ty abort
@@ -147,7 +150,6 @@ export class ProcessExecutor {
           // This is a temp implementation, this should be done with executionStep.action?.()
           // but this requires to be able to dynamically set the action function which is not possible for now
           // instead, we hard code the action behavior here as we only have 2 different actions to manage.
-
           this.emailRetrievalOperationsCallBack(executionStep.id);
         })
         // ignored - to be improved see https://typescript-eslint.io/rules/no-floating-promises/

--- a/src/case-monitoring/supplier-utils.ts
+++ b/src/case-monitoring/supplier-utils.ts
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 import {type BpmnVisualization, type ShapeStyleUpdate} from 'bpmn-visualization';
+import {delay} from '../utils/shared.js';
 
 function logProcessExecution(message: string, ...optionalParameters: any[]): void {
   console.info(`[EXEC] ${message}`, ...optionalParameters);
@@ -110,10 +111,7 @@ export class ProcessExecutor {
     const markAsExecuted = async (id: string, isEdge: boolean, waitDuration: number) => Promise.resolve(id)
       .then(id => this.pathHighlighter.markAsExecuted(id, isEdge))
       .then(id => this.markAsExecuted(id))
-    // eslint-disable-next-line  no-promise-executor-return -- improve declaration of this timeout
-      .then(async id => new Promise(resolve => setTimeout(() => {
-        resolve(id);
-      }, waitDuration)))
+      .then(async () => delay(waitDuration))
       .then(() => {
         logProcessExecution(`end of wait after ${id} highlight`);
       });
@@ -167,11 +165,7 @@ export class ProcessExecutor {
       logProcessExecution('DONE call execution of next step', executionStep.nextExecutionStep);
     } else if (executionStep.isLastStep) {
       logProcessExecution('registering endCaseCallBack call');
-      new Promise<void>(resolve => {
-        setTimeout(() => {
-          resolve();
-        }, processExecutorWaitTimeBeforeCallingEndCaseCallback);
-      })
+      delay(processExecutorWaitTimeBeforeCallingEndCaseCallback)
         .then(() => {
           logProcessExecution('detected as last step, so clearing everything');
           this.clear();

--- a/src/case-monitoring/supplier-utils.ts
+++ b/src/case-monitoring/supplier-utils.ts
@@ -87,7 +87,7 @@ export class ProcessExecutor {
 
   private readonly executionCounts = new Map<string, number>();
 
-  constructor(bpmnVisualization: BpmnVisualization, private readonly endCaseCallBack: () => void) {
+  constructor(bpmnVisualization: BpmnVisualization, private readonly emailRetrievalOperationsCallBack: (id: string) => void, private readonly endCaseCallBack: () => void) {
     this.pathHighlighter = new PathHighlighter(bpmnVisualization);
   }
 
@@ -143,6 +143,9 @@ export class ProcessExecutor {
     if (executionStep.action) {
       Promise.resolve()
         .then(() => executionStep.action?.())
+        .then(() => {
+          this.emailRetrievalOperationsCallBack(executionStep.id);
+        })
         // ignored - to be improved see https://typescript-eslint.io/rules/no-floating-promises/
         .finally(() => {
           // Nothing to do

--- a/src/case-monitoring/supplier.ts
+++ b/src/case-monitoring/supplier.ts
@@ -226,7 +226,7 @@ class SupplierContact {
   }
 
   // =====================================================================================================================
-  // For future usage, register dynamically this method at ProcessExecutor initialization
+  // Called by the ProcessExecutor
   // =====================================================================================================================
 
   // update/set the execution step action to call this function
@@ -258,7 +258,7 @@ class SupplierContact {
           .then(tippyInstance => {
             console.info('wait show email retrieval done - part 1');
             // TO DO manage types
-            (tippyInstance as Instance).setContent('Please be patient....');
+            (tippyInstance as Instance).setContent('Please be patient, ChatGPT is working for you...');
             console.info('content updated');
             delay(secondDelay, tippyInstance)
               .then(tippyInstance => {

--- a/src/case-monitoring/supplier.ts
+++ b/src/case-monitoring/supplier.ts
@@ -1,6 +1,7 @@
 import {type BpmnVisualization} from 'bpmn-visualization';
 import {type Instance, type ReferenceElement} from 'tippy.js';
 import {mainBpmnVisualization as bpmnVisualization, ProcessVisualizer} from '../diagram.js';
+import {delay} from '../utils/shared.js';
 import {AbstractCaseMonitoring, AbstractTippySupport} from './abstract.js';
 import {getExecutionStepAfterReviewEmailChoice, ProcessExecutor} from './supplier-utils.js';
 
@@ -239,11 +240,6 @@ class SupplierContact {
         .then(() => {
           console.info('review email popover is displayed!');
         });
-    }
-
-    async function delay(ms: number, args: any) {
-      // eslint-disable-next-line no-promise-executor-return -- cannot be managed now
-      return new Promise(timeup => setTimeout(timeup, ms, args));
     }
 
     // eslint-disable-next-line no-warning-comments -- cannot be managed now

--- a/src/case-monitoring/supplier.ts
+++ b/src/case-monitoring/supplier.ts
@@ -216,20 +216,40 @@ class SupplierContact {
   // =====================================================================================================================
 
   // update/set the execution step action to call this function
+  // TODO declare as arrow function to avoid rebind
   protected async emailRetrievalOperations(activityId: string): Promise<void> {
+    function delay(ms: number, args: any) {
+      return new Promise(resolve => setTimeout(resolve, ms, args));
+    }
+    // TODO too much promises here
+    const firstDelay = 1_500;
+    const secondDelay = 2_000;
     return Promise.resolve()
       .then(() => this.addInfo(activityId))
       // eslint-disable-next-line no-promise-executor-return
-      .then(async result => new Promise(resolve => setTimeout(() => {
-        resolve(result);
-      }, 1000)))
-      .then(() => {
-        console.info('wait show email retrieval 1 done');
-      });
+      .then(tippyInstance => {
+            console.info('register delay');
+            delay(firstDelay, tippyInstance)
+                .then(tippyInstance => {
+                  console.info('wait show email retrieval done - part 1');
+                  // TODO manage types
+                  (tippyInstance as Instance).setContent('Please be patient....')
+                  console.info('content updated');
+                  delay(secondDelay, tippyInstance)
+                      .then(tippyInstance => {
+                        console.info('wait show email retrieval done - part 2');
+                        (tippyInstance as Instance).hide();
+                        console.info('popover hidden');
+                        // hard coded for now, could be pass a method parameter in the future
+                        this.processExecutor?.execute('Activity_1oxewnq')
+                      });
+                });
+          }
+      )
   }
   //
   // // private emailRetrievalTippyInstance?: Instance;
-  // private showEmailRetrievalPopover() {
+  // private showEmailRetrievalPopover(activityId: string) {
   //   const retrieveEmailActivityId = this.bpmnElementsSearcher.getElementIdByName('Retrieve email suggestion')!;
   //   const tippySupport = this.supplierMonitoring.getTippySupportInstance();
   //

--- a/src/case-monitoring/supplier.ts
+++ b/src/case-monitoring/supplier.ts
@@ -234,8 +234,8 @@ class SupplierContact {
     const firstDelay = 1_500;
     const secondDelay = 2_000;
     return Promise.resolve()
+// TODO see if we can add a delay before the popover is displayed (with the delay tippy option)
       .then(() => this.addInfo(activityId))
-      // eslint-disable-next-line no-promise-executor-return
       .then(tippyInstance => {
             console.info('register delay');
             delay(firstDelay, tippyInstance)

--- a/src/case-monitoring/supplier.ts
+++ b/src/case-monitoring/supplier.ts
@@ -77,15 +77,29 @@ class SupplierProcessTippySupport extends AbstractTippySupport {
     }
   }
 
+  private hidePopoverOnClick(): void {
+    const bpmnElementId = 'Activity_1oxewnq'; // Hard coded for now "review and adapt email"
+
+    // Duplicated with process-monitoring removePopover --> candidate to extract for reuse
+    const bpmnElement = bpmnVisualization.bpmnElementsRegistry.getElementsByIds(bpmnElementId)[0];
+    const htmlElement = bpmnElement.htmlElement;
+    if ('_tippy' in htmlElement) {
+      (htmlElement._tippy as Instance).hide();
+    }
+  }
+
   private readonly onAbortClick = () => {
+    this.hidePopoverOnClick();
     supplierContact.abortClicked();
   };
 
   private readonly onValidateClick = () => {
+    this.hidePopoverOnClick();
     supplierContact.validateClicked();
   };
 
   private readonly onGenerateClick = () => {
+    this.hidePopoverOnClick();
     supplierContact.generateClicked();
   };
 

--- a/src/case-monitoring/supplier.ts
+++ b/src/case-monitoring/supplier.ts
@@ -136,7 +136,7 @@ class SupplierContact {
   // TODO this could should really be async!!!
   async startCase(): Promise<void> {
     console.info('called startCase');
-    this.processExecutor = new ProcessExecutor(this.bpmnVisualization, this.emailRetrievalOperations.bind(this), this.onEndCase);
+    this.processExecutor = new ProcessExecutor(this.bpmnVisualization, this.onEndCase, this.emailRetrievalOperations.bind(this));
     const processExecutorStarter = Promise.resolve(this.processExecutor);
 
     console.info('Registering ProcessExecutor start');

--- a/src/case-monitoring/supplier.ts
+++ b/src/case-monitoring/supplier.ts
@@ -229,21 +229,22 @@ class SupplierContact {
     }
 
     async function delay(ms: number, args: any) {
-      return new Promise(resolve => setTimeout(resolve, ms, args));
+      // eslint-disable-next-line no-promise-executor-return -- cannot be managed now
+      return new Promise(timeup => setTimeout(timeup, ms, args));
     }
 
+    // eslint-disable-next-line no-warning-comments -- cannot be managed now
     // TODO too much promises here
     const firstDelay = 1500;
     const secondDelay = 2000;
     return Promise.resolve()
-    // TODO see if we can add a delay before the popover is displayed (with the delay tippy option)
       .then(() => this.addInfo(activityId))
       .then(tippyInstance => {
         console.info('register delay');
         delay(firstDelay, tippyInstance)
           .then(tippyInstance => {
             console.info('wait show email retrieval done - part 1');
-            // TODO manage types
+            // TO DO manage types
             (tippyInstance as Instance).setContent('Please be patient....');
             console.info('content updated');
             delay(secondDelay, tippyInstance)
@@ -252,8 +253,15 @@ class SupplierContact {
                 (tippyInstance as Instance).hide();
                 console.info('popover hidden');
                 // Hard coded for now, could be pass a method parameter in the future
+                // eslint-disable-next-line @typescript-eslint/no-floating-promises -- cannot be managed now
                 this.processExecutor?.execute('Activity_1oxewnq');
+              })
+              .finally(() => {
+                console.info('End of second delay mgt');
               });
+          })
+          .finally(() => {
+            console.info('End of first delay mgt');
           });
       },
       );

--- a/src/case-monitoring/supplier.ts
+++ b/src/case-monitoring/supplier.ts
@@ -136,7 +136,7 @@ class SupplierContact {
   // TODO this could should really be async!!!
   async startCase(): Promise<void> {
     console.info('called startCase');
-    this.processExecutor = new ProcessExecutor(this.bpmnVisualization, this.onEndCase, this.emailRetrievalOperations.bind(this));
+    this.processExecutor = new ProcessExecutor(this.bpmnVisualization, this.onEndCase, this.emailRetrievalOperations);
     const processExecutorStarter = Promise.resolve(this.processExecutor);
 
     console.info('Registering ProcessExecutor start');
@@ -216,8 +216,7 @@ class SupplierContact {
   // =====================================================================================================================
 
   // update/set the execution step action to call this function
-  // TODO declare as arrow function to avoid rebind
-  private async emailRetrievalOperations(activityId: string): Promise<void> {
+  private readonly emailRetrievalOperations = async (activityId: string): Promise<void> => {
     // Same logic as in SupplierProcessTippySupport
     // Activity "review email"
     if (activityId === 'Activity_1oxewnq') {
@@ -265,7 +264,7 @@ class SupplierContact {
           });
       },
       );
-  }
+  };
 }
 
 // =====================================================================================================================

--- a/src/case-monitoring/supplier.ts
+++ b/src/case-monitoring/supplier.ts
@@ -28,7 +28,7 @@ class SupplierProcessTippySupport extends AbstractTippySupport {
 
   protected getContent(htmlElement: ReferenceElement) {
     const bpmnSemantic = this.registeredBpmnElements.get(htmlElement);
-    // Activity retreieve email suggestion
+    // Activity retrieve email suggestion
     if (bpmnSemantic?.id === 'Activity_04d6t36') {
       return this.getEmailRetrievalContent();
     }
@@ -217,7 +217,16 @@ class SupplierContact {
 
   // update/set the execution step action to call this function
   // TODO declare as arrow function to avoid rebind
-  protected async emailRetrievalOperations(activityId: string): Promise<void> {
+  private async emailRetrievalOperations(activityId: string): Promise<void> {
+    // same logic as in SupplierProcessTippySupport
+    // Activity "review email"
+    if (activityId === 'Activity_1oxewnq') {
+      return Promise.resolve()
+          .then(() => this.addInfo(activityId))
+          .then(() => console.info("review email popover is displayed!"))
+          ;
+    }
+
     function delay(ms: number, args: any) {
       return new Promise(resolve => setTimeout(resolve, ms, args));
     }
@@ -249,25 +258,25 @@ class SupplierContact {
   }
   //
   // // private emailRetrievalTippyInstance?: Instance;
-  // private showEmailRetrievalPopover(activityId: string) {
-  //   const retrieveEmailActivityId = this.bpmnElementsSearcher.getElementIdByName('Retrieve email suggestion')!;
-  //   const tippySupport = this.supplierMonitoring.getTippySupportInstance();
-  //
-  //   // const tippyInstance = this.supplierMonitoring.addPopoverOnElement(activityId);
-  //   const tippyInstance = tippySupport.addPopover(retrieveEmailActivityId);
-  //   tippyInstance.setContent('The content of the manually displayed instance);
-  //   tippyInstance.setProps({
-  //     trigger: 'manual',
-  //     arrow: false,
-  //     hideOnClick: false,
-  //   });
-  //   // return tippyInstance;
-  //
-  //   // prompt = 'Draft an email to ask about the supplier about the delay';
-  //   // this.emailRetrievalTippyInstance = this.addInfo(retrieveEmailActivityId, 'Draft an email to ask about the supplier about the delay', 'answer');
-  //   tippyInstance.show();
-  //   return tippyInstance;
-  // }
+  // private showEmailRetrievalPopover = (activityId: string) => {
+    // const retrieveEmailActivityId = this.bpmnElementsSearcher.getElementIdByName('Retrieve email suggestion')!;
+    // const tippySupport = this.supplierMonitoring.getTippySupportInstance();
+    //
+    // // const tippyInstance = this.supplierMonitoring.addPopoverOnElement(activityId);
+    // const tippyInstance = tippySupport.addPopover(retrieveEmailActivityId);
+    // tippyInstance.setContent('The content of the manually displayed instance);
+    // tippyInstance.setProps({
+    //   trigger: 'manual',
+    //   arrow: false,
+    //   hideOnClick: false,
+    // });
+    // // return tippyInstance;
+    //
+    // // prompt = 'Draft an email to ask about the supplier about the delay';
+    // // this.emailRetrievalTippyInstance = this.addInfo(retrieveEmailActivityId, 'Draft an email to ask about the supplier about the delay', 'answer');
+    // tippyInstance.show();
+    // return tippyInstance;
+  // };
 }
 
 // =====================================================================================================================

--- a/src/case-monitoring/supplier.ts
+++ b/src/case-monitoring/supplier.ts
@@ -218,65 +218,46 @@ class SupplierContact {
   // update/set the execution step action to call this function
   // TODO declare as arrow function to avoid rebind
   private async emailRetrievalOperations(activityId: string): Promise<void> {
-    // same logic as in SupplierProcessTippySupport
+    // Same logic as in SupplierProcessTippySupport
     // Activity "review email"
     if (activityId === 'Activity_1oxewnq') {
       return Promise.resolve()
-          .then(() => this.addInfo(activityId))
-          .then(() => console.info("review email popover is displayed!"))
-          ;
+        .then(() => this.addInfo(activityId))
+        .then(() => {
+          console.info('review email popover is displayed!');
+        });
     }
 
-    function delay(ms: number, args: any) {
+    async function delay(ms: number, args: any) {
       return new Promise(resolve => setTimeout(resolve, ms, args));
     }
+
     // TODO too much promises here
-    const firstDelay = 1_500;
-    const secondDelay = 2_000;
+    const firstDelay = 1500;
+    const secondDelay = 2000;
     return Promise.resolve()
-// TODO see if we can add a delay before the popover is displayed (with the delay tippy option)
+    // TODO see if we can add a delay before the popover is displayed (with the delay tippy option)
       .then(() => this.addInfo(activityId))
       .then(tippyInstance => {
-            console.info('register delay');
-            delay(firstDelay, tippyInstance)
-                .then(tippyInstance => {
-                  console.info('wait show email retrieval done - part 1');
-                  // TODO manage types
-                  (tippyInstance as Instance).setContent('Please be patient....')
-                  console.info('content updated');
-                  delay(secondDelay, tippyInstance)
-                      .then(tippyInstance => {
-                        console.info('wait show email retrieval done - part 2');
-                        (tippyInstance as Instance).hide();
-                        console.info('popover hidden');
-                        // hard coded for now, could be pass a method parameter in the future
-                        this.processExecutor?.execute('Activity_1oxewnq')
-                      });
-                });
-          }
-      )
+        console.info('register delay');
+        delay(firstDelay, tippyInstance)
+          .then(tippyInstance => {
+            console.info('wait show email retrieval done - part 1');
+            // TODO manage types
+            (tippyInstance as Instance).setContent('Please be patient....');
+            console.info('content updated');
+            delay(secondDelay, tippyInstance)
+              .then(tippyInstance => {
+                console.info('wait show email retrieval done - part 2');
+                (tippyInstance as Instance).hide();
+                console.info('popover hidden');
+                // Hard coded for now, could be pass a method parameter in the future
+                this.processExecutor?.execute('Activity_1oxewnq');
+              });
+          });
+      },
+      );
   }
-  //
-  // // private emailRetrievalTippyInstance?: Instance;
-  // private showEmailRetrievalPopover = (activityId: string) => {
-    // const retrieveEmailActivityId = this.bpmnElementsSearcher.getElementIdByName('Retrieve email suggestion')!;
-    // const tippySupport = this.supplierMonitoring.getTippySupportInstance();
-    //
-    // // const tippyInstance = this.supplierMonitoring.addPopoverOnElement(activityId);
-    // const tippyInstance = tippySupport.addPopover(retrieveEmailActivityId);
-    // tippyInstance.setContent('The content of the manually displayed instance);
-    // tippyInstance.setProps({
-    //   trigger: 'manual',
-    //   arrow: false,
-    //   hideOnClick: false,
-    // });
-    // // return tippyInstance;
-    //
-    // // prompt = 'Draft an email to ask about the supplier about the delay';
-    // // this.emailRetrievalTippyInstance = this.addInfo(retrieveEmailActivityId, 'Draft an email to ask about the supplier about the delay', 'answer');
-    // tippyInstance.show();
-    // return tippyInstance;
-  // };
 }
 
 // =====================================================================================================================

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -1,0 +1,21 @@
+/*
+Copyright 2023 Bonitasoft S.A.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// To improve, we may use existing libraries like the ones listed in https://geshan.com.np/blog/2022/08/javascript-wait-1-second/
+export const delay = async (ms: number, args?: any) =>
+// eslint-disable-next-line no-promise-executor-return -- cannot be managed now
+  new Promise(timeup => setTimeout(timeup, ms, args));
+


### PR DESCRIPTION
- on the "email generation" activity: display the popover and change its content
- then, continue the execution
- then, display the popover to decide what to do with the suggested email
- hide the popover when clicking on the buttons
- end case: remove the path highlight only at the end, after having wait, just before hiding the process


closes #64 

### Videos

https://user-images.githubusercontent.com/27200110/227160375-e9416d52-aedf-4623-bd1a-5a9a95a6dc6e.mp4

