### PR TITLE
feat(case-monitoring): rework the 'Supplier Contact' popovers

### DIFF
--- a/src/case-monitoring/abstract.ts
+++ b/src/case-monitoring/abstract.ts
@@ -71,7 +71,6 @@ export abstract class AbstractTippySupport {
     // eslint-disable-next-line @typescript-eslint/no-this-alias,unicorn/no-this-assignment -- temp
     const thisInstance = this;
     const tippyInstance = tippy(bpmnElement.htmlElement, {
-      theme: 'light',
       placement: 'bottom',
       appendTo: this.bpmnVisualization.graph.container,
       content: 'Loading...',

--- a/src/case-monitoring/main-process.ts
+++ b/src/case-monitoring/main-process.ts
@@ -15,7 +15,6 @@ limitations under the License.
 */
 
 import {type Instance, type ReferenceElement} from 'tippy.js';
-import 'tippy.js/dist/tippy.css';
 import type {BpmnVisualization} from 'bpmn-visualization';
 import {AbstractCaseMonitoring, AbstractTippySupport} from './abstract.js';
 import {getActivityRecommendationData} from './data-recommendation.js';

--- a/src/case-monitoring/supplier.ts
+++ b/src/case-monitoring/supplier.ts
@@ -35,7 +35,6 @@ class SupplierProcessTippySupport extends AbstractTippySupport {
       return this.getEmailRetrievalContent();
     }
     // Activity Review and adapt email
-
     return this.getEmailReviewContent();
   }
 
@@ -117,15 +116,16 @@ class SupplierProcessTippySupport extends AbstractTippySupport {
     const answer = getAnswer();
     let popoverContent = `
         <div class="popover-container">
+          <h4>Review email proposed by ChatGPT</h4>
           <table>
             <tbody>
               <tr>
-                <td>Prompt: </td>
-                <td><textarea cols="30" rows="3">${prompt}</textarea>
-              </tr>       
+                <td>Suggestion</td>
+                <td><textarea cols="30" rows="6">${answer}</textarea>
+              </tr>
               <tr>
-                <td>ChatGPT:</td>
-                <td><textarea cols="30" rows="5">${answer}</textarea>
+                <td>Prompt</td>
+                <td><textarea cols="30" rows="3">${prompt}</textarea>
               </tr>
             </tbody>
           </table>`;
@@ -221,13 +221,19 @@ class SupplierContact {
     this.mainProcessCaseMonitoring?.resume();
   };
 
-  protected addInfo(activityId: string) {
+  private addInfo(activityId: string) {
     const tippyInstance = this.supplierMonitoring.addInfoOnChatGptActivity(activityId);
-    // TippyInstance.setContent('the content to set manually - chatgpt is working');
+      // Activity_04d6t36 chatGPT activity
+      // Activity_1oxewnq review email
+    const isChatGPTActivity = activityId === 'Activity_04d6t36';
     tippyInstance.setProps({
+      theme: isChatGPTActivity ? 'light': '',
       trigger: 'manual',
-      arrow: false,
+      arrow: !isChatGPTActivity,
+      placement: isChatGPTActivity ? 'bottom' : 'top',
       hideOnClick: false,
+      // default is 350px
+      maxWidth: isChatGPTActivity ? '350px': '450px',
     });
     tippyInstance.show();
     return tippyInstance;
@@ -261,7 +267,7 @@ class SupplierContact {
           .then(tippyInstance => {
             console.info('wait show email retrieval done - part 1');
             // TO DO manage types
-            (tippyInstance as Instance).setContent('Please be patient, ChatGPT is working for you...');
+            (tippyInstance as Instance).setContent(this.getChatGPTWaitMessage());
             console.info('content updated');
             delay(secondDelay, tippyInstance)
               .then(tippyInstance => {
@@ -282,6 +288,13 @@ class SupplierContact {
       },
       );
   };
+
+  private getChatGPTWaitMessage(): string {
+    return `<div style="display: flex; width: 11rem;">
+    <div class="loading mr-2" style="flex-basis: 1rem;"></div>
+    <div>ChatGPT is working for you...</div>
+  </div>`;
+  }
 }
 
 // =====================================================================================================================

--- a/src/case-monitoring/supplier.ts
+++ b/src/case-monitoring/supplier.ts
@@ -34,6 +34,7 @@ class SupplierProcessTippySupport extends AbstractTippySupport {
     if (bpmnSemantic?.id === 'Activity_04d6t36') {
       return this.getEmailRetrievalContent();
     }
+
     // Activity Review and adapt email
     return this.getEmailReviewContent();
   }
@@ -223,17 +224,17 @@ class SupplierContact {
 
   private addInfo(activityId: string) {
     const tippyInstance = this.supplierMonitoring.addInfoOnChatGptActivity(activityId);
-      // Activity_04d6t36 chatGPT activity
-      // Activity_1oxewnq review email
-    const isChatGPTActivity = activityId === 'Activity_04d6t36';
+    // Activity_04d6t36 chatGPT activity
+    // Activity_1oxewnq review email
+    const isChatGptActivity = activityId === 'Activity_04d6t36';
     tippyInstance.setProps({
-      theme: isChatGPTActivity ? 'light': '',
+      theme: isChatGptActivity ? 'light' : '',
       trigger: 'manual',
-      arrow: !isChatGPTActivity,
-      placement: isChatGPTActivity ? 'bottom' : 'top',
+      arrow: !isChatGptActivity,
+      placement: isChatGptActivity ? 'bottom' : 'top',
       hideOnClick: false,
-      // default is 350px
-      maxWidth: isChatGPTActivity ? '350px': '450px',
+      // Default is 350px
+      maxWidth: isChatGptActivity ? '350px' : '450px',
     });
     tippyInstance.show();
     return tippyInstance;
@@ -267,7 +268,7 @@ class SupplierContact {
           .then(tippyInstance => {
             console.info('wait show email retrieval done - part 1');
             // TO DO manage types
-            (tippyInstance as Instance).setContent(this.getChatGPTWaitMessage());
+            (tippyInstance as Instance).setContent(this.getChatGptWaitMessage());
             console.info('content updated');
             delay(secondDelay, tippyInstance)
               .then(tippyInstance => {
@@ -289,7 +290,7 @@ class SupplierContact {
       );
   };
 
-  private getChatGPTWaitMessage(): string {
+  private getChatGptWaitMessage(): string {
     return `<div style="display: flex; width: 11rem;">
     <div class="loading mr-2" style="flex-basis: 1rem;"></div>
     <div>ChatGPT is working for you...</div>

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,8 @@ limitations under the License.
 */
 
 import 'spectre.css/dist/spectre-icons.css';
+import 'tippy.js/dist/tippy.css';
+import 'tippy.js/themes/light.css';
 import {configureBreadcrumb} from './breadcrumb.js';
 import {configureUseCaseSelectors, defaultUseCase} from './use-case-management.js';
 

--- a/src/process-monitoring.ts
+++ b/src/process-monitoring.ts
@@ -185,7 +185,6 @@ export class ProcessMonitoring {
     const bpmnElement = this.bpmnElementsRegistry.getElementsByIds(bpmnElementId)[0];
 
     return tippy(bpmnElement.htmlElement, {
-      theme: 'light',
       placement: 'top',
       animation: 'scale',
       appendTo: this.bpmnVisualization.graph.container,

--- a/src/style.css
+++ b/src/style.css
@@ -294,20 +294,18 @@ header {
 /* More generally case-monitoring */
 /* ================================================================================================================== */
 
-/*padding: 10px;
-}*/
-
 .popover-container {
   max-width: 400px;
-  margin-top: 4px;
-  margin-bottom: 4px;
+  margin-top: .2rem;
+  margin-bottom: .2rem;
 }
 
 .popover-container textarea {
   max-width: 100%;
   width: 100%;
   box-sizing: border-box;
-  padding: 8px;
+  padding: .4rem;
+  resize: none;
 }
 
 table {


### PR DESCRIPTION
"review suggestion"
  - layout: display the suggestion first to have the prompt close to the buttons
  - make the textarea non-resizable
  - add arrow to popover like in all popovers where users can act

"email generation"
  - use tippy light theme
  - add loading spinner in the 2nd message

Fix tippy theme loading:
  - use the tippy 'default' theme by default
  - allow to load the tippy 'light' theme

Also includes some refactoring:
  - style: use rem instead of px (popover)
  - supplier addInfo: simplify options computation


closes #83

### Screenshots

https://user-images.githubusercontent.com/27200110/227782423-61a2dce9-ed71-412a-8e03-ef97ebec623e.mp4


