### PR TITLE
fix(case-monitoring): disable use-case switch in "Supplier"

### DIFF
--- a/src/case-monitoring/supplier.ts
+++ b/src/case-monitoring/supplier.ts
@@ -2,6 +2,7 @@ import {type BpmnVisualization} from 'bpmn-visualization';
 import {type Instance, type Props, type ReferenceElement} from 'tippy.js';
 import {mainBpmnVisualization as bpmnVisualization, ProcessVisualizer} from '../diagram.js';
 import {delay} from '../utils/shared.js';
+import {disableUseCaseSelectors, enableUseCaseSelectors} from '../use-case-selectors';
 import {AbstractCaseMonitoring, AbstractTippySupport} from './abstract.js';
 import {type MainProcessCaseMonitoring} from './main-process.js';
 import {type InnerActionParameters, ProcessExecutor, type ReviewEmailDecision} from './supplier-utils.js';
@@ -168,6 +169,7 @@ class SupplierContact {
 
   async startCase(): Promise<void> {
     console.info('called startCase');
+    disableUseCaseSelectors();
     const processExecutorStarter = Promise.resolve(this.processExecutor);
     console.info('Registering ProcessExecutor start');
     processExecutorStarter.then(async processExecutor => processExecutor.start())
@@ -186,6 +188,7 @@ class SupplierContact {
 
   onEndCase = (): void => {
     this.stopCase();
+    enableUseCaseSelectors();
     this.mainProcessCaseMonitoring?.resume();
   };
 

--- a/src/case-monitoring/supplier.ts
+++ b/src/case-monitoring/supplier.ts
@@ -2,7 +2,7 @@ import {type BpmnVisualization} from 'bpmn-visualization';
 import {type Instance, type Props, type ReferenceElement} from 'tippy.js';
 import {mainBpmnVisualization as bpmnVisualization, ProcessVisualizer} from '../diagram.js';
 import {delay} from '../utils/shared.js';
-import {disableUseCaseSelectors, enableUseCaseSelectors} from '../use-case-selectors';
+import {disableUseCaseSelectors, enableUseCaseSelectors} from '../use-case-selectors.js';
 import {AbstractCaseMonitoring, AbstractTippySupport} from './abstract.js';
 import {type MainProcessCaseMonitoring} from './main-process.js';
 import {type InnerActionParameters, ProcessExecutor, type ReviewEmailDecision} from './supplier-utils.js';

--- a/src/use-case-selectors.ts
+++ b/src/use-case-selectors.ts
@@ -1,0 +1,30 @@
+/*
+Copyright 2023 Bonitasoft S.A.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+const updateUseCaseSelectorsState = (disable: boolean): void => {
+  const radios = document.querySelectorAll<HTMLInputElement>('#control input[type=radio]');
+  for (const radio of radios) {
+    radio.disabled = disable;
+  }
+};
+
+export const disableUseCaseSelectors = (): void => {
+  updateUseCaseSelectorsState(true);
+};
+
+export const enableUseCaseSelectors = (): void => {
+  updateUseCaseSelectorsState(false);
+};


### PR DESCRIPTION
Currently, the "Supplier Contact" process cannot be stopped properly. To avoid side effects, disable the ability to change use cases while it is running.

fixes #58