### PR TITLE
refactor: reorganize notifications

### DIFF
--- a/src/case-monitoring/sub-process.ts
+++ b/src/case-monitoring/sub-process.ts
@@ -17,12 +17,10 @@ limitations under the License.
 import {type BpmnVisualization} from 'bpmn-visualization';
 import {type Instance} from 'tippy.js';
 import {displayView, isSubProcessBpmnDiagramIsAlreadyLoad, subProcessBpmnVisualization, subProcessViewName} from '../diagram.js';
-import {configureToast, NotyfType, toast} from '../utils/shared.js';
+import {Notification} from '../utils/shared.js';
 import {AbstractCaseMonitoring, AbstractTippySupport} from './abstract.js';
-import 'notyf/notyf.min.css';
 
-const notyfDuration = 3000;
-const notyf = configureToast(notyfDuration);
+const notification = new Notification(3000);
 
 class SubProcessCaseMonitoring extends AbstractCaseMonitoring {
   constructor(bpmnVisualization: BpmnVisualization, tippySupport: SubProcessTippySupport) {
@@ -103,7 +101,7 @@ class SubProcessTippySupport extends AbstractTippySupport {
     const button = event.currentTarget as HTMLButtonElement;
     const row = button.closest('tr')!;
     const toastMessage = `The task has been assigned to <b>${row.cells[0].textContent ?? ''}</b>`;
-    toast(notyf, NotyfType.Success, toastMessage);
+    notification.toast('success', toastMessage);
   };
 
   // Hack from https://stackoverflow.com/questions/56079864/how-to-remove-an-event-listener-within-a-class

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+import 'notyf/notyf.min.css';
 import 'spectre.css/dist/spectre-icons.css';
 import 'tippy.js/dist/tippy.css';
 import 'tippy.js/themes/light.css';

--- a/src/utils/shared.ts
+++ b/src/utils/shared.ts
@@ -22,37 +22,36 @@ export const delay = async (ms: number, args?: any) =>
   new Promise(timeup => setTimeout(timeup, ms, args));
 
 // Notification configuration
+export type NotificationType = 'success' | 'warning';
 
-export enum NotyfType {
-  Success = 'success',
-  Warning = 'warning',
-}
+export class Notification {
+  private readonly notyf: Notyf;
 
-export function configureToast(notyfDuration: number) {
-  return new Notyf({
-    position: {
-      x: 'center',
-      y: 'top',
-    },
-    types: [
-      {
-        type: NotyfType.Success,
-        duration: notyfDuration,
+  constructor(duration: number) {
+    this.notyf = new Notyf({
+      position: {
+        x: 'center',
+        y: 'top',
       },
-      {
-        type: NotyfType.Warning,
-        duration: notyfDuration,
-        background: '#ff8c00',
-        icon: false,
-      },
-    ],
-  });
-}
+      types: [
+        {
+          type: 'success' as NotificationType,
+          duration,
+        },
+        {
+          type: 'warning' as NotificationType,
+          duration,
+          background: '#ff8c00',
+          icon: false,
+        },
+      ],
+    });
+  }
 
-export function toast(notyf: Notyf, type: string, htmlMessage: string) {
-  notyf.open({
-    type,
-    message: htmlMessage,
-  });
+  toast(type: NotificationType, htmlMessage: string) {
+    this.notyf.open({
+      type,
+      message: htmlMessage,
+    });
+  }
 }
-


### PR DESCRIPTION
Introduce a class to hide the 'Notyf' library to the code using the notification. This makes the notification easier to create and remove adherence to an external library at several places in the application.

Don't hard code the condition that triggers the display of notifications in `ProcessExecutor`. `ProcessExecutor` is intended to be as general as possible for a future near reuse outside of this demonstration
Notifications are now made configurable in the `ExecutionStep`.

Change NotificationType from enum to type. There is no need to enumerate the values and TS enum doesn't operate very well with JS code, so let's avoid them when alternatives exist.

### Notes

Include remarks done in https://github.com/process-analytics/bonita-day-demo-2023/pull/94#pullrequestreview-1360919275