### PR TITLE
chore: let run as Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,2 @@
+FROM nginx:stable-alpine3.17-slim
+COPY dist /usr/share/nginx/html

--- a/README.md
+++ b/README.md
@@ -25,6 +25,26 @@ The code should be linted with [xo](https://github.com/xojs/xo). To have support
 To lint the code, run `npm run lint`.
 
 
+### Run as a Docker container
+
+Build the demo:
+```shell
+npm install
+npm run build
+```
+
+Build the Docker image
+```shell
+docker build -t process-analytics:bonita-day-demo-2023 .
+```
+
+Start a container (adapt the `3617` value to use another port)
+```shell
+docker run --name pa-bonita-day-demo-2023 -d -p 3617:80 process-analytics:bonita-day-demo-2023
+```
+Then you can hit http://localhost:3617 or http://host-ip:3617 in your browser.
+
+
 ## 📃 License
 
 The code of this demo is released under the [Apache 2.0](LICENSE) license.


### PR DESCRIPTION
Explain how to build the Docker image and run the Docker container. Use nginx alpine as HTTP server. The image size is currently 13MB.

### Tests done

Tested on Ubuntu 20.04 running Docker Engine - Community Version 23.0.2
```
$docker version
Client: Docker Engine - Community
 Version:           23.0.2
 API version:       1.42
 Go version:        go1.19.7
 Git commit:        569dd73
 Built:             Mon Mar 27 16:16:18 2023
 OS/Arch:           linux/amd64
 Context:           default

Server: Docker Engine - Community
 Engine:
  Version:          23.0.2
  API version:      1.42 (minimum version 1.12)
  Go version:       go1.19.7
  Git commit:       219f21b
  Built:            Mon Mar 27 16:16:18 2023
  OS/Arch:          linux/amd64
  Experimental:     false
 containerd:
  Version:          1.6.19
  GitCommit:        1e1ea6e986c6c86565bc33d52e34b81b3e2bc71f
 runc:
  Version:          1.1.4
  GitCommit:        v1.1.4-0-g5fd4c4d
 docker-init:
  Version:          0.19.0
  GitCommit:        de40ad0
```