### PR TITLE
refactor(case-monitoring): simplify sub-process hide data

### DIFF
--- a/src/case-monitoring/sub-process.ts
+++ b/src/case-monitoring/sub-process.ts
@@ -16,7 +16,7 @@ limitations under the License.
 
 import {type BpmnVisualization} from 'bpmn-visualization';
 import {type Instance} from 'tippy.js';
-import {displayView, isSubProcessBpmnDiagramIsAlreadyLoad, subProcessBpmnVisualization, subProcessViewName} from '../diagram.js';
+import {displayView, subProcessBpmnVisualization, subProcessViewName} from '../diagram.js';
 import {Notification} from '../utils/shared.js';
 import {AbstractCaseMonitoring, AbstractTippySupport} from './abstract.js';
 
@@ -192,29 +192,7 @@ function getWarningInfoAsHtml() {
 const subProcessCaseMonitoring = new SubProcessCaseMonitoring(subProcessBpmnVisualization, new SubProcessTippySupport(subProcessBpmnVisualization));
 
 export function hideSubProcessCaseMonitoringData() {
-  // Currently mandatory, if the diagram is not loaded error, this seems to be a bug in bpmn-visualization
-  // calling getElementsByIds when the diagram is not loaded generates an error. It should respond without errors.
-  // seen with bpmn-visualization@0.32.0
-  // 15:40:09,653 Uncaught TypeError: this.searchableModel is undefined
-  //     getBpmnSemantic bpmn-visualization.esm.js:6067
-  //     getElementsByIds bpmn-visualization.esm.js:5742
-  //     getElementsByIds bpmn-visualization.esm.js:5742
-  //     getVisitedEdges paths.ts:30
-  //     fetchCaseMonitoringData data-case.ts:120
-  //     getCaseMonitoringData abstract.ts:32
-  //     restoreVisibilityOfAlreadyExecutedElements abstract.ts:67
-  //     hideData abstract.ts:25
-  //     hideSubProcessCaseMonitoringData case-monitoring.ts:262
-  //     configureUseCaseSelectors use-case-management.ts:36
-  //     unselect use-case-management.ts:69
-  //     UseCaseSelector use-case-management.ts:53
-  //     UseCaseSelector use-case-management.ts:51
-  //     configureUseCaseSelectors use-case-management.ts:38
-  //     <anonymous> index.ts:37
-  // bpmn-visualization.esm.js:6067:24
-  if (isSubProcessBpmnDiagramIsAlreadyLoad()) {
-    subProcessCaseMonitoring.hideData();
-  }
+  subProcessCaseMonitoring.hideData();
 }
 
 // eslint-disable-next-line no-warning-comments -- cannot be managed now

--- a/src/diagram.ts
+++ b/src/diagram.ts
@@ -42,10 +42,6 @@ class DiagramLoadManager {
 const mainProcessDiagramLoadManager = new DiagramLoadManager(mainBpmnVisualization, mainDiagram);
 const subProcessDiagramLoadManager = new DiagramLoadManager(subProcessBpmnVisualization, subDiagram);
 
-// eslint-disable-next-line no-warning-comments -- cannot be managed now
-// TODO do not leak internal state
-export const isSubProcessBpmnDiagramIsAlreadyLoad = () => subProcessDiagramLoadManager.isAlreadyLoad();
-
 export function displayView(view: View): void {
   if (currentView === view) {
     return;

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -26,8 +26,12 @@ export class PathResolver {
 
   getVisitedEdges(shapeIds: string[]): string[] {
     const edgeIds = new Set<string>();
-    for (const shape of shapeIds) {
-      const shapeElt = this.bpmnVisualization.bpmnElementsRegistry.getElementsByIds(shape)[0];
+    for (const shapeId of shapeIds) {
+      const shapeElt = this.bpmnVisualization.bpmnElementsRegistry.getElementsByIds(shapeId)[0];
+      if (!shapeElt) {
+        continue;
+      }
+
       const bpmnSemantic = shapeElt.bpmnSemantic as ShapeBpmnSemantic;
       const incomingEdges = bpmnSemantic.incomingIds;
       const outgoingEdges = bpmnSemantic.outgoingIds;


### PR DESCRIPTION
This is possible thanks to a fix available in bpmn-visualization 0.33.1. Previously, the data could only be hidden if the sub-process diagram was already loaded. This forced to leak the internal state and made the code harder to understand.

Also improve the robustness of the PathResolver to handle shapeId that are not available in the diagram. Here, this lets support not loaded diagram.