### PR TITLE
refactor: use the new "remove all CSS classes" API

### DIFF
--- a/src/case-monitoring/abstract.ts
+++ b/src/case-monitoring/abstract.ts
@@ -37,7 +37,7 @@ export abstract class AbstractCaseMonitoring {
 
   protected resetRunningElements() {
     const bpmnElementIds = this.getCaseMonitoringData().runningShapes;
-    this.bpmnVisualization.bpmnElementsRegistry.removeCssClasses(bpmnElementIds, ['state-running-late', 'state-enabled', 'state-waiting']);
+    this.bpmnVisualization.bpmnElementsRegistry.removeAllCssClasses(bpmnElementIds);
     for (const bpmnElementId of bpmnElementIds) {
       this.bpmnVisualization.bpmnElementsRegistry.removeAllOverlays(bpmnElementId);
     }

--- a/src/process-monitoring.ts
+++ b/src/process-monitoring.ts
@@ -128,17 +128,7 @@ export class ProcessMonitoring {
   }
 
   private hideHappyPath() {
-    this.bpmnElementsRegistry.removeCssClasses(happyPath, [
-      'highlight-happy-path',
-      'pulse-happy',
-      'gateway-happy',
-      'growing-happy',
-      ...happyPath.map(elementId => {
-        const styleOfElement = document.querySelector(`#${elementId}`);
-        styleOfElement?.parentNode?.removeChild(styleOfElement);
-        return `animate-${elementId}`;
-      }),
-    ]);
+    this.bpmnElementsRegistry.removeAllCssClasses(happyPath);
 
     // Remove popover
     this.removePopover(happyPathElementWithPopover);


### PR DESCRIPTION
This avoids passing the ids of the BPMN elements and/or the name of the CSS classes.

closes #11 