### PR TITLE
refactor: directly use BpmnElementsRegistry when possible

### DIFF
--- a/src/case-monitoring/abstract.ts
+++ b/src/case-monitoring/abstract.ts
@@ -1,12 +1,14 @@
-import {type BpmnElement, type BpmnSemantic, type BpmnVisualization} from 'bpmn-visualization/*';
+import type {BpmnElement, BpmnElementsRegistry, BpmnSemantic, BpmnVisualization} from 'bpmn-visualization';
 import tippy, {type Instance, type Props, type ReferenceElement} from 'tippy.js';
 import {type CaseMonitoringData, fetchCaseMonitoringData} from './data-case.js';
 
 export abstract class AbstractCaseMonitoring {
+  protected readonly bpmnElementsRegistry: BpmnElementsRegistry;
   protected caseMonitoringData: CaseMonitoringData | undefined;
 
   protected constructor(protected readonly bpmnVisualization: BpmnVisualization, private readonly processId: string, protected tippySupport: AbstractTippySupport) {
     console.info('Initialized AbstractCaseMonitoring, processId: %s / bpmn-container: %s', processId, bpmnVisualization.graph.container.id);
+    this.bpmnElementsRegistry = bpmnVisualization.bpmnElementsRegistry;
   }
 
   showData(): void {
@@ -37,33 +39,36 @@ export abstract class AbstractCaseMonitoring {
 
   protected resetRunningElements() {
     const bpmnElementIds = this.getCaseMonitoringData().runningShapes;
-    this.bpmnVisualization.bpmnElementsRegistry.removeAllCssClasses(bpmnElementIds);
+    this.bpmnElementsRegistry.removeAllCssClasses(bpmnElementIds);
     for (const bpmnElementId of bpmnElementIds) {
-      this.bpmnVisualization.bpmnElementsRegistry.removeAllOverlays(bpmnElementId);
+      this.bpmnElementsRegistry.removeAllOverlays(bpmnElementId);
     }
 
     this.tippySupport.removeAllPopovers();
   }
 
   private reduceVisibilityOfAlreadyExecutedElements(): void {
-    this.bpmnVisualization.bpmnElementsRegistry.addCssClasses([...this.getCaseMonitoringData().executedShapes, ...this.getCaseMonitoringData().visitedEdges], 'state-already-executed');
+    this.bpmnElementsRegistry.addCssClasses([...this.getCaseMonitoringData().executedShapes, ...this.getCaseMonitoringData().visitedEdges], 'state-already-executed');
   }
 
   private restoreVisibilityOfAlreadyExecutedElements() {
-    this.bpmnVisualization.bpmnElementsRegistry.removeCssClasses([...this.getCaseMonitoringData().executedShapes, ...this.getCaseMonitoringData().visitedEdges], 'state-already-executed');
+    this.bpmnElementsRegistry.removeCssClasses([...this.getCaseMonitoringData().executedShapes, ...this.getCaseMonitoringData().visitedEdges], 'state-already-executed');
   }
 }
 
 // May change in the future to favor composition over inheritance.
 export abstract class AbstractTippySupport {
+  protected readonly bpmnElementsRegistry: BpmnElementsRegistry;
   protected registeredBpmnElements = new Map<Element, BpmnSemantic>();
 
   private readonly tippyInstances: Instance[] = [];
 
-  constructor(protected readonly bpmnVisualization: BpmnVisualization) {}
+  constructor(protected readonly bpmnVisualization: BpmnVisualization) {
+    this.bpmnElementsRegistry = bpmnVisualization.bpmnElementsRegistry;
+  }
 
   addPopover(bpmnElementId: string) {
-    const bpmnElement = this.bpmnVisualization.bpmnElementsRegistry.getElementsByIds(bpmnElementId)[0];
+    const bpmnElement = this.bpmnElementsRegistry.getElementsByIds(bpmnElementId)[0];
     this.registerBpmnElement(bpmnElement);
 
     // eslint-disable-next-line no-warning-comments -- cannot be managed now

--- a/src/case-monitoring/data-case.ts
+++ b/src/case-monitoring/data-case.ts
@@ -16,7 +16,7 @@ abstract class AbstractCaseMonitoringDataProvider {
   protected readonly bpmnElementsSearcher: BpmnElementsSearcher;
   private readonly pathResolver: PathResolver;
 
-  protected constructor(protected readonly bpmnVisualization: BpmnVisualization) {
+  constructor(bpmnVisualization: BpmnVisualization) {
     this.bpmnElementsSearcher = new BpmnElementsSearcher(bpmnVisualization);
     this.pathResolver = new PathResolver(bpmnVisualization);
   }
@@ -46,10 +46,6 @@ abstract class AbstractCaseMonitoringDataProvider {
 }
 
 class MainProcessCaseMonitoringDataProvider extends AbstractCaseMonitoringDataProvider {
-  constructor(protected readonly bpmnVisualization: BpmnVisualization) {
-    super(bpmnVisualization);
-  }
-
   getExecutedShapes(): string[] {
     const shapes: string[] = [];
     addNonNullElement(shapes, this.bpmnElementsSearcher.getElementIdByName('New POI needed')); // Start event
@@ -73,10 +69,6 @@ class MainProcessCaseMonitoringDataProvider extends AbstractCaseMonitoringDataPr
 }
 
 class SubProcessCaseMonitoringDataProvider extends AbstractCaseMonitoringDataProvider {
-  constructor(protected readonly bpmnVisualization: BpmnVisualization) {
-    super(bpmnVisualization);
-  }
-
   getExecutedShapes(): string[] {
     const shapes: string[] = [];
     addNonNullElement(shapes, 'Event_1dnxra5'); // Start event

--- a/src/case-monitoring/data-case.ts
+++ b/src/case-monitoring/data-case.ts
@@ -1,4 +1,4 @@
-import {type BpmnVisualization} from 'bpmn-visualization';
+import type {BpmnElementsRegistry, BpmnVisualization} from 'bpmn-visualization';
 import {BpmnElementsSearcher} from '../utils/bpmn-elements.js';
 import {PathResolver} from '../utils/paths.js';
 
@@ -16,9 +16,9 @@ abstract class AbstractCaseMonitoringDataProvider {
   protected readonly bpmnElementsSearcher: BpmnElementsSearcher;
   private readonly pathResolver: PathResolver;
 
-  constructor(bpmnVisualization: BpmnVisualization) {
-    this.bpmnElementsSearcher = new BpmnElementsSearcher(bpmnVisualization);
-    this.pathResolver = new PathResolver(bpmnVisualization);
+  constructor(bpmnElementsRegistry: BpmnElementsRegistry) {
+    this.bpmnElementsSearcher = new BpmnElementsSearcher(bpmnElementsRegistry);
+    this.pathResolver = new PathResolver(bpmnElementsRegistry);
   }
 
   /**
@@ -89,13 +89,14 @@ class SubProcessCaseMonitoringDataProvider extends AbstractCaseMonitoringDataPro
 }
 
 export function fetchCaseMonitoringData(processId: string, bpmnVisualization: BpmnVisualization): CaseMonitoringData {
-  const caseMonitoringDataProvider = processId === 'main' ? new MainProcessCaseMonitoringDataProvider(bpmnVisualization) : new SubProcessCaseMonitoringDataProvider(bpmnVisualization);
+  const bpmnElementsRegistry = bpmnVisualization.bpmnElementsRegistry;
+  const caseMonitoringDataProvider = processId === 'main' ? new MainProcessCaseMonitoringDataProvider(bpmnElementsRegistry) : new SubProcessCaseMonitoringDataProvider(bpmnElementsRegistry);
 
   const executedShapes = caseMonitoringDataProvider.getExecutedShapes();
   const runningShapes = caseMonitoringDataProvider.getRunningShapes();
   const pendingShapes = caseMonitoringDataProvider.getPendingShapes();
 
-  const visitedEdges = new PathResolver(bpmnVisualization).getVisitedEdges([...executedShapes, ...runningShapes, ...pendingShapes]);
+  const visitedEdges = new PathResolver(bpmnElementsRegistry).getVisitedEdges([...executedShapes, ...runningShapes, ...pendingShapes]);
   return {
     executedShapes,
     pendingShapes,

--- a/src/case-monitoring/main-process.ts
+++ b/src/case-monitoring/main-process.ts
@@ -43,17 +43,17 @@ export class MainProcessCaseMonitoring extends AbstractCaseMonitoring {
   // pause: on main activity, remove popover, remove overlays, remove CSS + add CSS like in subprocess
   pause(): void {
     this.resetRunningElements();
-    this.bpmnVisualization.bpmnElementsRegistry.addCssClasses(this.getCaseMonitoringData().runningShapes, 'state-enabled');
+    this.bpmnElementsRegistry.addCssClasses(this.getCaseMonitoringData().runningShapes, 'state-enabled');
   }
 
   // Resume
   resume(): void {
-    this.bpmnVisualization.bpmnElementsRegistry.removeCssClasses(this.getCaseMonitoringData().runningShapes, 'state-enabled');
+    this.bpmnElementsRegistry.removeCssClasses(this.getCaseMonitoringData().runningShapes, 'state-enabled');
     this.highlightRunningElements();
   }
 
   protected highlightRunningElements(): void {
-    this.bpmnVisualization.bpmnElementsRegistry.addCssClasses(this.getCaseMonitoringData().runningShapes, 'state-running-late');
+    this.bpmnElementsRegistry.addCssClasses(this.getCaseMonitoringData().runningShapes, 'state-running-late');
     this.addInfoOnRunningElements(this.getCaseMonitoringData().runningShapes);
   }
 
@@ -67,10 +67,6 @@ export class MainProcessCaseMonitoring extends AbstractCaseMonitoring {
 
 class MainProcessTippySupport extends AbstractTippySupport {
   private mainProcessCaseMonitoring?: MainProcessCaseMonitoring;
-
-  constructor(protected readonly bpmnVisualization: BpmnVisualization) {
-    super(bpmnVisualization);
-  }
 
   setMainProcessCaseMonitoring(mainProcessCaseMonitoring: MainProcessCaseMonitoring) {
     this.mainProcessCaseMonitoring = mainProcessCaseMonitoring;

--- a/src/case-monitoring/sub-process.ts
+++ b/src/case-monitoring/sub-process.ts
@@ -28,7 +28,7 @@ class SubProcessCaseMonitoring extends AbstractCaseMonitoring {
   }
 
   protected highlightRunningElements(): void {
-    this.bpmnVisualization.bpmnElementsRegistry.addCssClasses(this.getCaseMonitoringData().runningShapes, 'state-waiting');
+    this.bpmnElementsRegistry.addCssClasses(this.getCaseMonitoringData().runningShapes, 'state-waiting');
     this.addInfoOnRunningElements(this.getCaseMonitoringData().runningShapes);
   }
 
@@ -124,8 +124,8 @@ class SubProcessTippySupport extends AbstractTippySupport {
   // Highlight activities that have already been managed by the current resource
   private highlightBpmnElements(data: Map<string, number>): void {
     for (const [bpmnElementId, nbExec] of data) {
-      this.bpmnVisualization.bpmnElementsRegistry.addCssClasses(bpmnElementId, 'already-completed-by-user');
-      this.bpmnVisualization.bpmnElementsRegistry.addOverlays(bpmnElementId, {
+      this.bpmnElementsRegistry.addCssClasses(bpmnElementId, 'already-completed-by-user');
+      this.bpmnElementsRegistry.addOverlays(bpmnElementId, {
         position: 'top-center',
         label: `${nbExec}`,
         style: {
@@ -139,8 +139,8 @@ class SubProcessTippySupport extends AbstractTippySupport {
 
   private resetStyleOfBpmnElements(bpmnElementIds: string[]): void {
     for (const bpmnElementId of bpmnElementIds) {
-      this.bpmnVisualization.bpmnElementsRegistry.removeCssClasses(bpmnElementId, 'already-completed-by-user');
-      this.bpmnVisualization.bpmnElementsRegistry.removeAllOverlays(bpmnElementId);
+      this.bpmnElementsRegistry.removeCssClasses(bpmnElementId, 'already-completed-by-user');
+      this.bpmnElementsRegistry.removeAllOverlays(bpmnElementId);
     }
   }
 }

--- a/src/case-monitoring/supplier-utils.ts
+++ b/src/case-monitoring/supplier-utils.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type {BpmnElementsRegistry, BpmnVisualization, Overlay, ShapeStyleUpdate} from 'bpmn-visualization';
+import type {BpmnElementsRegistry, Overlay, ShapeStyleUpdate} from 'bpmn-visualization';
 import {delay, Notification, type NotificationType} from '../utils/shared.js';
 
 function logProcessExecution(message: string, ...optionalParameters: unknown[]): void {
@@ -143,8 +143,8 @@ export class ProcessExecutor {
   private readonly executionCounts = new Map<string, number>();
 
   // EmailRetrievalOperationsCallBack is passed as we cannot get it from the ExecutionStep defined below for now
-  constructor(bpmnVisualization: BpmnVisualization, private readonly endCaseCallBack: () => void, private readonly emailRetrievalOperationsCallBack: (parameters: InnerActionParameters) => void) {
-    this.pathHighlighter = new PathHighlighter(bpmnVisualization);
+  constructor(bpmnElementsRegistry: BpmnElementsRegistry, private readonly endCaseCallBack: () => void, private readonly emailRetrievalOperationsCallBack: (parameters: InnerActionParameters) => void) {
+    this.pathHighlighter = new PathHighlighter(bpmnElementsRegistry);
   }
 
   async start() {
@@ -290,17 +290,13 @@ export class ProcessExecutor {
 }
 
 class PathHighlighter {
-  private readonly bpmnElementsRegistry: BpmnElementsRegistry;
-
   private readonly executedPath = new Set<string>();
 
   private pastExecutedId: string | undefined;
   private lastExecutedId: string | undefined;
   private readonly executionCounts = new Map<string, number>();
 
-  constructor(bpmnVisualization: BpmnVisualization) {
-    this.bpmnElementsRegistry = bpmnVisualization.bpmnElementsRegistry;
-  }
+  constructor(private readonly bpmnElementsRegistry: BpmnElementsRegistry) {}
 
   markAsExecuted(marker: PathHighlightMarker) {
     const id = marker.id;

--- a/src/case-monitoring/supplier.ts
+++ b/src/case-monitoring/supplier.ts
@@ -25,10 +25,6 @@ class SupplierProcessCaseMonitoring extends AbstractCaseMonitoring {
 }
 
 class SupplierProcessTippySupport extends AbstractTippySupport {
-  constructor(protected readonly bpmnVisualization: BpmnVisualization) {
-    super(bpmnVisualization);
-  }
-
   // For ChatGPT popovers, we cannot only rely on the super.addPopover method
   // We manage 2 popovers, that don't have the same design
   // We need specific methods to add/remove listeners on "review email" buttons

--- a/src/case-monitoring/supplier.ts
+++ b/src/case-monitoring/supplier.ts
@@ -155,8 +155,8 @@ class SupplierContact {
   private readonly processExecutor: ProcessExecutor;
   private mainProcessCaseMonitoring?: MainProcessCaseMonitoring;
 
-  constructor(private readonly bpmnVisualization: BpmnVisualization, readonly supplierMonitoring: SupplierProcessCaseMonitoring) {
-    this.processExecutor = new ProcessExecutor(this.bpmnVisualization, this.onEndCase, this.emailRetrievalOperations);
+  constructor(bpmnVisualization: BpmnVisualization, readonly supplierMonitoring: SupplierProcessCaseMonitoring) {
+    this.processExecutor = new ProcessExecutor(bpmnVisualization.bpmnElementsRegistry, this.onEndCase, this.emailRetrievalOperations);
   }
 
   setMainProcessCaseMonitoring(mainProcessCaseMonitoring: MainProcessCaseMonitoring) {

--- a/src/diagram.ts
+++ b/src/diagram.ts
@@ -117,12 +117,9 @@ const doSubProcessNavigation = () => {
 };
 
 export class SubProcessNavigator {
-  private readonly bpmnElementsRegistry: BpmnElementsRegistry;
   private subProcessHtmlElement: HTMLElement | undefined;
 
-  constructor(bpmnVisualization: BpmnVisualization) {
-    this.bpmnElementsRegistry = bpmnVisualization.bpmnElementsRegistry;
-  }
+  constructor(private readonly bpmnElementsRegistry: BpmnElementsRegistry) {}
 
   enable() {
     this.getSubProcessHtmlElement().addEventListener('click', doSubProcessNavigation);

--- a/src/diagram.ts
+++ b/src/diagram.ts
@@ -1,4 +1,4 @@
-import {BpmnVisualization, FitType, type LoadOptions} from 'bpmn-visualization';
+import {type BpmnElementsRegistry, BpmnVisualization, FitType, type LoadOptions} from 'bpmn-visualization';
 // eslint-disable-next-line n/file-extension-in-import -- Vite syntax
 import mainDiagram from './diagrams/EC-purchase-orders-collapsed.bpmn?raw';
 // eslint-disable-next-line n/file-extension-in-import -- Vite syntax
@@ -117,23 +117,26 @@ const doSubProcessNavigation = () => {
 };
 
 export class SubProcessNavigator {
+  private readonly bpmnElementsRegistry: BpmnElementsRegistry;
   private subProcessHtmlElement: HTMLElement | undefined;
 
-  constructor(private readonly bpmnVisualization: BpmnVisualization) {}
+  constructor(bpmnVisualization: BpmnVisualization) {
+    this.bpmnElementsRegistry = bpmnVisualization.bpmnElementsRegistry;
+  }
 
   enable() {
     this.getSubProcessHtmlElement().addEventListener('click', doSubProcessNavigation);
-    this.bpmnVisualization.bpmnElementsRegistry.addCssClasses(subProcessId, 'c-hand');
+    this.bpmnElementsRegistry.addCssClasses(subProcessId, 'c-hand');
   }
 
   disable() {
     this.getSubProcessHtmlElement().removeEventListener('click', doSubProcessNavigation);
-    this.bpmnVisualization.bpmnElementsRegistry.removeCssClasses(subProcessId, 'c-hand');
+    this.bpmnElementsRegistry.removeCssClasses(subProcessId, 'c-hand');
   }
 
   private getSubProcessHtmlElement() {
     if (!this.subProcessHtmlElement) {
-      this.subProcessHtmlElement = this.bpmnVisualization.bpmnElementsRegistry.getElementsByIds(subProcessId)[0].htmlElement;
+      this.subProcessHtmlElement = this.bpmnElementsRegistry.getElementsByIds(subProcessId)[0].htmlElement;
     }
 
     return this.subProcessHtmlElement;

--- a/src/process-monitoring.ts
+++ b/src/process-monitoring.ts
@@ -74,7 +74,7 @@ export class ProcessMonitoring {
   private readonly bpmnElementsIdentifier: BpmnElementsIdentifier;
   constructor(private readonly bpmnVisualization: BpmnVisualization) {
     this.bpmnElementsRegistry = bpmnVisualization.bpmnElementsRegistry;
-    this.bpmnElementsIdentifier = new BpmnElementsIdentifier(bpmnVisualization);
+    this.bpmnElementsIdentifier = new BpmnElementsIdentifier(this.bpmnElementsRegistry);
   }
 
   start() {

--- a/src/use-case-management.ts
+++ b/src/use-case-management.ts
@@ -1,9 +1,9 @@
 import {newMainProcessCaseMonitoring} from './case-monitoring/main-process.js';
 import {
+  displayView,
   mainBpmnVisualization as bpmnVisualization,
   ProcessVisualizer,
   SubProcessNavigator,
-  displayView,
 } from './diagram.js';
 import {ProcessMonitoring} from './process-monitoring.js';
 
@@ -15,7 +15,7 @@ export const defaultUseCase = 'reset-all';
 
 export function configureUseCaseSelectors(selectedUseCase: string) {
   const processVisualizer = new ProcessVisualizer(bpmnVisualization);
-  const subProcessNavigator = new SubProcessNavigator(bpmnVisualization);
+  const subProcessNavigator = new SubProcessNavigator(bpmnVisualization.bpmnElementsRegistry);
 
   const processMonitoring = new ProcessMonitoring(bpmnVisualization);
   const mainProcessCaseMonitoring = newMainProcessCaseMonitoring(bpmnVisualization);

--- a/src/utils/bpmn-elements.ts
+++ b/src/utils/bpmn-elements.ts
@@ -17,7 +17,6 @@ limitations under the License.
 import {
   type BpmnElementsRegistry,
   type BpmnSemantic,
-  type BpmnVisualization,
   ShapeBpmnElementKind,
   ShapeUtil,
 } from 'bpmn-visualization';
@@ -26,11 +25,7 @@ import {
  * Provides workarounds for {@link https://github.com/process-analytics/bpmn-visualization-js/issues/2453}.
  */
 export class BpmnElementsSearcher {
-  private readonly bpmnElementsRegistry: BpmnElementsRegistry;
-
-  constructor(bpmnVisualization: BpmnVisualization) {
-    this.bpmnElementsRegistry = bpmnVisualization.bpmnElementsRegistry;
-  }
+  constructor(private readonly bpmnElementsRegistry: BpmnElementsRegistry) {}
 
   getElementIdByName(name: string): string | undefined {
     return this.getElementByName(name)?.id;
@@ -60,11 +55,7 @@ export class BpmnElementsSearcher {
 }
 
 export class BpmnElementsIdentifier {
-  private readonly bpmnElementsRegistry: BpmnElementsRegistry;
-
-  constructor(bpmnVisualization: BpmnVisualization) {
-    this.bpmnElementsRegistry = bpmnVisualization.bpmnElementsRegistry;
-  }
+  constructor(private readonly bpmnElementsRegistry: BpmnElementsRegistry) {}
 
   isActivity(elementId: string): boolean {
     return this.isInCategory(ShapeUtil.isActivity, elementId);

--- a/src/utils/bpmn-elements.ts
+++ b/src/utils/bpmn-elements.ts
@@ -14,13 +14,23 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import {type BpmnSemantic, type BpmnVisualization, ShapeBpmnElementKind, ShapeUtil} from 'bpmn-visualization';
+import {
+  type BpmnElementsRegistry,
+  type BpmnSemantic,
+  type BpmnVisualization,
+  ShapeBpmnElementKind,
+  ShapeUtil,
+} from 'bpmn-visualization';
 
 /**
  * Provides workarounds for {@link https://github.com/process-analytics/bpmn-visualization-js/issues/2453}.
  */
 export class BpmnElementsSearcher {
-  constructor(private readonly bpmnVisualization: BpmnVisualization) {}
+  private readonly bpmnElementsRegistry: BpmnElementsRegistry;
+
+  constructor(bpmnVisualization: BpmnVisualization) {
+    this.bpmnElementsRegistry = bpmnVisualization.bpmnElementsRegistry;
+  }
 
   getElementIdByName(name: string): string | undefined {
     return this.getElementByName(name)?.id;
@@ -32,7 +42,7 @@ export class BpmnElementsSearcher {
     const kinds = Object.values(ShapeBpmnElementKind);
     // Split query by kind to avoid returning a big chunk of data
     for (const kind of kinds) {
-      const bpmnSemantics = this.bpmnVisualization.bpmnElementsRegistry.getElementsByKinds(kind)
+      const bpmnSemantics = this.bpmnElementsRegistry.getElementsByKinds(kind)
         .map(elt => elt.bpmnSemantic)
         .filter(Boolean);
 
@@ -50,7 +60,11 @@ export class BpmnElementsSearcher {
 }
 
 export class BpmnElementsIdentifier {
-  constructor(private readonly bpmnVisualization: BpmnVisualization) {}
+  private readonly bpmnElementsRegistry: BpmnElementsRegistry;
+
+  constructor(bpmnVisualization: BpmnVisualization) {
+    this.bpmnElementsRegistry = bpmnVisualization.bpmnElementsRegistry;
+  }
 
   isActivity(elementId: string): boolean {
     return this.isInCategory(ShapeUtil.isActivity, elementId);
@@ -65,7 +79,7 @@ export class BpmnElementsIdentifier {
   }
 
   private isInCategory(categorizeFunction: (value: string) => boolean, elementId: string): boolean {
-    const elements = this.bpmnVisualization.bpmnElementsRegistry.getElementsByIds(elementId);
+    const elements = this.bpmnElementsRegistry.getElementsByIds(elementId);
     if (elements.length > 0) {
       const kind = elements[0].bpmnSemantic.kind;
       return categorizeFunction(kind);

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type {BpmnElementsRegistry, BpmnVisualization, EdgeBpmnSemantic, ShapeBpmnSemantic} from 'bpmn-visualization';
+import type {BpmnElementsRegistry, EdgeBpmnSemantic, ShapeBpmnSemantic} from 'bpmn-visualization';
 
 /**
  * Experimental implementation for
@@ -22,11 +22,7 @@ import type {BpmnElementsRegistry, BpmnVisualization, EdgeBpmnSemantic, ShapeBpm
  * - {@link https://github.com/process-analytics/bpmn-visualization-js/issues/2402}
  */
 export class PathResolver {
-  private readonly bpmnElementsRegistry: BpmnElementsRegistry;
-
-  constructor(bpmnVisualization: BpmnVisualization) {
-    this.bpmnElementsRegistry = bpmnVisualization.bpmnElementsRegistry;
-  }
+  constructor(private readonly bpmnElementsRegistry: BpmnElementsRegistry) {}
 
   getVisitedEdges(shapeIds: string[]): string[] {
     const edgeIds = new Set<string>();

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-import type {BpmnVisualization, EdgeBpmnSemantic, ShapeBpmnSemantic} from 'bpmn-visualization';
+import type {BpmnElementsRegistry, BpmnVisualization, EdgeBpmnSemantic, ShapeBpmnSemantic} from 'bpmn-visualization';
 
 /**
  * Experimental implementation for
@@ -22,12 +22,16 @@ import type {BpmnVisualization, EdgeBpmnSemantic, ShapeBpmnSemantic} from 'bpmn-
  * - {@link https://github.com/process-analytics/bpmn-visualization-js/issues/2402}
  */
 export class PathResolver {
-  constructor(private readonly bpmnVisualization: BpmnVisualization) {}
+  private readonly bpmnElementsRegistry: BpmnElementsRegistry;
+
+  constructor(bpmnVisualization: BpmnVisualization) {
+    this.bpmnElementsRegistry = bpmnVisualization.bpmnElementsRegistry;
+  }
 
   getVisitedEdges(shapeIds: string[]): string[] {
     const edgeIds = new Set<string>();
     for (const shapeId of shapeIds) {
-      const shapeElt = this.bpmnVisualization.bpmnElementsRegistry.getElementsByIds(shapeId)[0];
+      const shapeElt = this.bpmnElementsRegistry.getElementsByIds(shapeId)[0];
       if (!shapeElt) {
         continue;
       }
@@ -36,7 +40,7 @@ export class PathResolver {
       const incomingEdges = bpmnSemantic.incomingIds;
       const outgoingEdges = bpmnSemantic.outgoingIds;
       for (const edgeId of incomingEdges) {
-        const edgeElement = this.bpmnVisualization.bpmnElementsRegistry.getElementsByIds(edgeId)[0];
+        const edgeElement = this.bpmnElementsRegistry.getElementsByIds(edgeId)[0];
         const sourceRef = (edgeElement.bpmnSemantic as EdgeBpmnSemantic).sourceRefId;
         if (shapeIds.includes(sourceRef)) {
           edgeIds.add(edgeId);
@@ -44,7 +48,7 @@ export class PathResolver {
       }
 
       for (const edgeId of outgoingEdges) {
-        const edgeElement = this.bpmnVisualization.bpmnElementsRegistry.getElementsByIds(edgeId)[0];
+        const edgeElement = this.bpmnElementsRegistry.getElementsByIds(edgeId)[0];
         const targetRef = (edgeElement.bpmnSemantic as EdgeBpmnSemantic).targetRefId;
         if (shapeIds.includes(targetRef)) {
           edgeIds.add(edgeId);


### PR DESCRIPTION
Use `BpmnElementsRegistry` properties in classes when possible instead of storing an instance of
`BpmnVisualization`. This makes the code easier to read and improve the intent.

Pass BpmnElementsRegistry parameter in constructors to simplify the constructor and reduce the dependency to the `BpmnVisualization` type when possible.

closes #52

### Notes

The change is split into 2 commits to facilitate revert or PR split. I don't think this is needed but who knows 😄