### PR TITLE
refactor: remove unused code

### DIFF
--- a/src/case-monitoring/data-case.ts
+++ b/src/case-monitoring/data-case.ts
@@ -91,18 +91,7 @@ class SubProcessCaseMonitoringDataProvider extends AbstractCaseMonitoringDataPro
 export function fetchCaseMonitoringData(processId: string, bpmnVisualization: BpmnVisualization): CaseMonitoringData {
   const bpmnElementsRegistry = bpmnVisualization.bpmnElementsRegistry;
   const caseMonitoringDataProvider = processId === 'main' ? new MainProcessCaseMonitoringDataProvider(bpmnElementsRegistry) : new SubProcessCaseMonitoringDataProvider(bpmnElementsRegistry);
-
-  const executedShapes = caseMonitoringDataProvider.getExecutedShapes();
-  const runningShapes = caseMonitoringDataProvider.getRunningShapes();
-  const pendingShapes = caseMonitoringDataProvider.getPendingShapes();
-
-  const visitedEdges = new PathResolver(bpmnElementsRegistry).getVisitedEdges([...executedShapes, ...runningShapes, ...pendingShapes]);
-  return {
-    executedShapes,
-    pendingShapes,
-    runningShapes,
-    visitedEdges,
-  };
+  return caseMonitoringDataProvider.fetch();
 }
 
 function addNonNullElement(elements: string[], elt: string | undefined) {

--- a/src/case-monitoring/data-recommendation.ts
+++ b/src/case-monitoring/data-recommendation.ts
@@ -17,10 +17,6 @@ recommendationData.set('SRM subprocess', [{
   description: 'Notify a delay'}],
 );
 
-export function getRecommendationData(): Map<string, ActivityRecommendations[]> {
-  return recommendationData;
-}
-
 export function getActivityRecommendationData(activityName: string): ActivityRecommendations[] {
   return recommendationData.get(activityName) ?? [];
 }

--- a/src/diagram.ts
+++ b/src/diagram.ts
@@ -31,10 +31,6 @@ class DiagramLoadManager {
       this.bpmnDiagramIsAlreadyLoad = true;
     }
   }
-
-  isAlreadyLoad(): boolean {
-    return this.bpmnDiagramIsAlreadyLoad;
-  }
 }
 
 const mainProcessDiagramLoadManager = new DiagramLoadManager(mainBpmnVisualization, mainDiagram);

--- a/src/style.css
+++ b/src/style.css
@@ -332,12 +332,12 @@ tr.popover-row:hover {
 
 .btn-success:hover {
   background-color: #3D8B37;
-  box-shadow: 0px 0px 2px 2px #74c56e;
+  box-shadow: 0 0 2px 2px #74c56e;
 }
 
 .btn-error:hover {
   background-color: #FF7373;
-  box-shadow: 0px 0px 2px 2px #FF7373;
+  box-shadow: 0 0 2px 2px #FF7373;
 }
 
 td.popover-key {


### PR DESCRIPTION
CaseMonitoringData: call the `fetch` method that was previously unused and the implementation was duplicated it.

Remove unused
  - getRecommendationData function
  - DiagramLoadManager.isAlreadyLoad

style.css: remove px unit when value set to 0